### PR TITLE
Fix API key assignment

### DIFF
--- a/examples/api_keys.py
+++ b/examples/api_keys.py
@@ -6,8 +6,6 @@ if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
 
-resend.api_key = os.environ["RESEND_API_KEY"]
-
 key = resend.ApiKeys.create(
     {
         "name": "prod",

--- a/examples/domains.py
+++ b/examples/domains.py
@@ -6,8 +6,6 @@ if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
 
-resend.api_key = os.environ["RESEND_API_KEY"]
-
 domain = resend.Domains.create(
     {
         "name": "domain.io",

--- a/examples/simple_email.py
+++ b/examples/simple_email.py
@@ -6,8 +6,6 @@ if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
 
-resend.api_key = os.environ["RESEND_API_KEY"]
-
 params = {
     "from": "r@email.io",
     "to": ["to@gmail.com"],

--- a/examples/with_attachments.py
+++ b/examples/with_attachments.py
@@ -5,7 +5,6 @@ import resend
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
-resend.api_key = os.environ["RESEND_API_KEY"]
 
 f = open(
     os.path.join(os.path.dirname(__file__), "../resources/invoice.pdf"), "rb"

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from .api import Resend
 from .api_keys import ApiKeys
 from .domains import Domains
@@ -6,7 +8,7 @@ from .request import Request
 from .version import get_version
 
 # Config vars
-api_key = None
+api_key = os.environ.get("RESEND_API_KEY")
 
 # API resources
 from .emails import Emails  # noqa


### PR DESCRIPTION
This pull request addresses an issue with assigning the API key from environment variables and ensures that no functionality is broken.

In the `resend/__init__.py` file, the assignment of the `api_key` variable has been updated to retrieve the API key from the environment variable `RESEND_API_KEY` using `os.environ.get()`. This change allows for more flexibility in managing the API key, removing the necessity of the `resend.api_key` assignment after importing it.

Redundant code in the example files has been removed. The `resend.api_key` assignment is no longer necessary since it is now retrieved from the environment variable directly.

These changes do not introduce any breaking changes and ensure the codebase is cleaner and more maintainable. Additionally, using the package now requires one line of code less. Please review  and consider merging this pull request.

Thank you!