### PR TITLE
api.resend.com in config ENV.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,6 @@ services:
     command: sleep infinity
     environment:
       RESEND_API_KEY: ${RESEND_API_KEY}
-      RESEND_API_URL: ${RESEND_API_URL}
+      RESEND_API_URL: ${RESEND_API_URL} # defaults value https://api.resend.com
     volumes:
       - .:/app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,5 +7,6 @@ services:
     command: sleep infinity
     environment:
       RESEND_API_KEY: ${RESEND_API_KEY}
+      RESEND_API_URL: ${RESEND_API_URL}
     volumes:
       - .:/app

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -10,6 +10,7 @@ from .version import get_version
 
 # Config vars
 api_key = os.environ.get("RESEND_API_KEY")
+api_url = os.environ.get("RESEND_API_URL", "https://api.resend.com")
 
 # API resources
 from .emails import Emails  # noqa

--- a/resend/request.py
+++ b/resend/request.py
@@ -9,15 +9,13 @@ from resend.version import get_version
 
 # This class wraps the HTTP request creation logic
 class Request:
-    base_url: str = resend.api_url
-
     def __init__(self, path: str, params: Dict, verb: str):
         self.path = path
         self.params = params
         self.verb = verb
 
     def perform(self):
-        resp = self.make_request(url=f"{self.base_url}{self.path}")
+        resp = self.make_request(url=f"{resend.api_url}{self.path}")
 
         # delete calls do not return a body
         if resp.text == "" and resp.status_code == 200:

--- a/resend/request.py
+++ b/resend/request.py
@@ -9,7 +9,7 @@ from resend.version import get_version
 
 # This class wraps the HTTP request creation logic
 class Request:
-    base_url: str = "https://api.resend.com"
+    base_url: str = resend.api_url
 
     def __init__(self, path: str, params: Dict, verb: str):
         self.path = path


### PR DESCRIPTION
resend API endpoint config ENV var 'RESEND_API_URL', be used for Cloudflare's works packaging.