### PR TITLE
changing params behavior to be required as Resend docs

### DIFF
--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -57,7 +57,7 @@ class ApiKeys:
         return [ApiKey.new_from_request(val) for val in resp["data"]]
 
     @classmethod
-    def remove(cls, api_key_id: str = "") -> None:
+    def remove(cls, api_key_id: str) -> None:
         """
         Remove an existing API key.
         see more: https://resend.com/docs/api-reference/api-keys/delete-api-key

--- a/resend/domains/_domains.py
+++ b/resend/domains/_domains.py
@@ -71,7 +71,7 @@ class Domains:
         )
 
     @classmethod
-    def get(cls, domain_id: str = "") -> Domain:
+    def get(cls, domain_id: str) -> Domain:
         """
         Retrieve a single domain for the authenticated user.
         see more: https://resend.com/docs/api-reference/domains/get-domain
@@ -101,10 +101,10 @@ class Domains:
         return [Domain.new_from_request(val) for val in resp["data"]]
 
     @classmethod
-    def remove(cls, domain_id: str = "") -> Domain:
+    def remove(cls, domain_id: str) -> Domain:
         """
         Remove an existing domain.
-        see more: https://resend.com/docs/api-reference/domains/remove-domain
+        see more: https://resend.com/docs/api-reference/domains/delete-domain
 
         Args:
             domain_id (str): The domain ID
@@ -118,7 +118,7 @@ class Domains:
         )
 
     @classmethod
-    def verify(cls, domain_id: str = "") -> Domain:
+    def verify(cls, domain_id: str) -> Domain:
         """
         Verify an existing domain.
         see more: https://resend.com/docs/api-reference/domains/verify-domain

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -80,7 +80,7 @@ class Emails:
         )
 
     @classmethod
-    def get(cls, email_id: str = "") -> Email:
+    def get(cls, email_id: str) -> Email:
         """
         Retrieve a single email.
         see more: https://resend.com/docs/api-reference/emails/retrieve-email


### PR DESCRIPTION
Following Resend docs, the parameters that were changed are `required`, so they shouldn't have a `default` value.

<img width="293" alt="Screenshot 2024-04-22 at 7 24 05 AM" src="https://github.com/resend/resend-python/assets/42066025/32aaa926-5f85-4ef3-b171-cdb5549ebdbc">
<img width="307" alt="Screenshot 2024-04-22 at 7 24 02 AM" src="https://github.com/resend/resend-python/assets/42066025/bf8ebd7c-3895-4c35-bfe7-036006aa1d46">
<img width="301" alt="Screenshot 2024-04-22 at 7 23 59 AM" src="https://github.com/resend/resend-python/assets/42066025/7c4c1727-5cb6-4564-9413-809c7e23930f">
<img width="337" alt="Screenshot 2024-04-22 at 7 23 55 AM" src="https://github.com/resend/resend-python/assets/42066025/527a0c36-95bc-4023-9324-1416f03ec646">
