### PR TITLE
chore: Make requests>=2.31

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.32.2
+requests>=2.31.0
 typing_extensions

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 
 def get_version() -> str:

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.1.0"
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={"resend": ["py.typed"]},
     install_requires=install_requires,
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     keywords=["email", "email platform"],
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -27,6 +27,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The SDK was originally supporting python 3.7.
Requests 2.32.0 requires 3.8+, so instead of pinning requests 2.32.0 which would make the resend python sdk dependent on python 3.8, im just making requests >= 2.31 so that we don't add the constraint of updating python version too.