### PR TITLE
Chore/email auxiliary types

### DIFF
--- a/resend/emails/_email.py
+++ b/resend/emails/_email.py
@@ -60,6 +60,7 @@ class Email(_EmailDefaultAttrs):
 
     Attributes:
         id (str): The Email ID.
+        from (str): The email address the email was sent from.
         to (Union[List[str], str]): List of email addresses to send the email to.
         created_at (str): When the email was created.
         subject (str): The subject of the email.

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -7,8 +7,18 @@ from resend.emails._attachment import Attachment
 from resend.emails._email import Email
 from resend.emails._tag import Tag
 
+# SendParamsFrom is declared with functional TypedDict syntax here because
+# "from" is a reserved keyword in Python, and this is the best way to
+# support type-checking for it.
+_SendParamsFrom = TypedDict(
+    "_SendParamsFrom",
+    {
+        "from": str,
+    },
+)
 
-class _SendParamsDefault(TypedDict):
+
+class _SendParamsDefault(_SendParamsFrom):
     to: Union[str, List[str]]
     """
     List of email addresses to send the email to.
@@ -51,19 +61,8 @@ class _SendParamsDefault(TypedDict):
     """
 
 
-# SendParamsFrom is declared with functional TypedDict syntax here because
-# "from" is a reserved keyword in Python, and this is the best way to
-# support type-checking for it.
-_SendParamsFrom = TypedDict(
-    "_SendParamsFrom",
-    {
-        "from": str,
-    },
-)
-
-
 class Emails:
-    class SendParams(_SendParamsDefault, _SendParamsFrom):
+    class SendParams(_SendParamsDefault):
         """SendParams is the class that wraps the parameters for the send method.
 
         Attributes:

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -8,61 +8,62 @@ from resend.emails._email import Email
 from resend.emails._tag import Tag
 
 
+class _SendParamsDefault(TypedDict):
+    to: Union[str, List[str]]
+    """
+    List of email addresses to send the email to.
+    """
+    subject: str
+    """
+    The subject of the email.
+    """
+    bcc: NotRequired[Union[List[str], str]]
+    """
+    Bcc
+    """
+    cc: NotRequired[Union[List[str], str]]
+    """
+    Cc
+    """
+    reply_to: NotRequired[Union[List[str], str]]
+    """
+    Reply to
+    """
+    html: NotRequired[str]
+    """
+    The HTML content of the email.
+    """
+    text: NotRequired[str]
+    """
+    The text content of the email.
+    """
+    headers: NotRequired[Dict[str, str]]
+    """
+    Custom headers to be added to the email.
+    """
+    attachments: NotRequired[List[Attachment]]
+    """
+    List of attachments to be added to the email.
+    """
+    tags: NotRequired[List[Tag]]
+    """
+    List of tags to be added to the email.
+    """
+
+
+# SendParamsFrom is declared with functional TypedDict syntax here because
+# "from" is a reserved keyword in Python, and this is the best way to
+# support type-checking for it.
+_SendParamsFrom = TypedDict(
+    "_SendParamsFrom",
+    {
+        "from": str,
+    },
+)
+
+
 class Emails:
-
-    class SendParamsDefault(TypedDict):
-        to: Union[str, List[str]]
-        """
-        List of email addresses to send the email to.
-        """
-        subject: str
-        """
-        The subject of the email.
-        """
-        bcc: NotRequired[Union[List[str], str]]
-        """
-        Bcc
-        """
-        cc: NotRequired[Union[List[str], str]]
-        """
-        Cc
-        """
-        reply_to: NotRequired[Union[List[str], str]]
-        """
-        Reply to
-        """
-        html: NotRequired[str]
-        """
-        The HTML content of the email.
-        """
-        text: NotRequired[str]
-        """
-        The text content of the email.
-        """
-        headers: NotRequired[Dict[str, str]]
-        """
-        Custom headers to be added to the email.
-        """
-        attachments: NotRequired[List[Attachment]]
-        """
-        List of attachments to be added to the email.
-        """
-        tags: NotRequired[List[Tag]]
-        """
-        List of tags to be added to the email.
-        """
-
-    # SendParamsFrom is declared with functional TypedDict syntax here because
-    # "from" is a reserved keyword in Python, and this is the best way to
-    # support type-checking for it.
-    _SendParamsFrom = TypedDict(
-        "_SendParamsFrom",
-        {
-            "from": str,
-        },
-    )
-
-    class SendParams(SendParamsDefault, _SendParamsFrom):
+    class SendParams(_SendParamsDefault, _SendParamsFrom):
         """SendParams is the class that wraps the parameters for the send method.
 
         Attributes:


### PR DESCRIPTION
## Improving docstring
- Include the 'from' attribute in the Email docstring 

## Emails types
- Removing unnecessary types from Emails class, because they are only auxiliary types to build SendParams
- Improving inheritance to build SendParams

We go from this:
<img width="158" alt="Screenshot 2024-05-26 at 11 08 14 AM" src="https://github.com/resend/resend-python/assets/42066025/99768603-13f2-4e61-a059-80b184d3367e">

To this:
<img width="111" alt="Screenshot 2024-05-26 at 11 07 50 AM" src="https://github.com/resend/resend-python/assets/42066025/07a71a63-4ffb-4474-8bbd-fc1e2ef27245">
