### PR TITLE
Feat/generics request

### DIFF
--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -53,12 +53,9 @@ class ApiKeys:
             ApiKey: The new API key object
         """
         path = "/api-keys"
-        return cast(
-            ApiKey,
-            request.Request(
-                path=path, params=cast(Dict[Any, Any], params), verb="post"
-            ).perform(),
-        )
+        return request.Request[ApiKey](
+            path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform()
 
     @classmethod
     def list(cls) -> ListResponse:
@@ -70,8 +67,9 @@ class ApiKeys:
             ListResponse: A list of API key objects
         """
         path = "/api-keys"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(_ListResponse, resp)
+        return request.Request[cls.ListResponse](
+            path=path, params={}, verb="get"
+        ).perform()
 
     @classmethod
     def remove(cls, api_key_id: str) -> None:
@@ -88,5 +86,5 @@ class ApiKeys:
         path = f"/api-keys/{api_key_id}"
 
         # This would raise if failed
-        request.Request(path=path, params={}, verb="delete").perform()
+        _ = request.Request[None](path=path, params={}, verb="delete").perform()
         return None

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -4,6 +4,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.api_keys._api_key import ApiKey
+from resend.exceptions import NoContentError
 
 
 class _ListResponse(TypedDict):
@@ -53,9 +54,12 @@ class ApiKeys:
             ApiKey: The new API key object
         """
         path = "/api-keys"
-        return request.Request[ApiKey](
+        resp = request.Request[ApiKey](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def list(cls) -> ListResponse:
@@ -67,9 +71,12 @@ class ApiKeys:
             ListResponse: A list of API key objects
         """
         path = "/api-keys"
-        return request.Request[cls.ListResponse](
+        resp = request.Request[_ListResponse](
             path=path, params={}, verb="get"
         ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def remove(cls, api_key_id: str) -> None:

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -56,9 +56,7 @@ class ApiKeys:
         path = "/api-keys"
         resp = request.Request[ApiKey](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -73,9 +71,7 @@ class ApiKeys:
         path = "/api-keys"
         resp = request.Request[_ListResponse](
             path=path, params={}, verb="get"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -88,5 +88,5 @@ class ApiKeys:
         path = f"/api-keys/{api_key_id}"
 
         # This would raise if failed
-        _ = request.Request[None](path=path, params={}, verb="delete").perform()
+        request.Request[None](path=path, params={}, verb="delete").perform()
         return None

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -4,7 +4,6 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.api_keys._api_key import ApiKey
-from resend.exceptions import NoContentError
 
 
 class _ListResponse(TypedDict):

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, cast
 from typing_extensions import TypedDict
 
 from resend import request
-from resend.exceptions import NoContentError
 
 from ._audience import Audience
 

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, cast
 from typing_extensions import TypedDict
 
 from resend import request
+from resend.exceptions import NoContentError
 
 from ._audience import Audience
 
@@ -43,10 +44,12 @@ class Audiences:
             Audience: The new audience object
         """
         path = "/audiences"
-        resp = request.Request(
+        resp = request.Request[Audience](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform()
-        return cast(Audience, resp)
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def list(cls) -> ListResponse:
@@ -58,8 +61,12 @@ class Audiences:
             ListResponse: A list of audience objects
         """
         path = "/audiences/"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(_ListResponse, resp)
+        resp = request.Request[_ListResponse](
+            path=path, params={}, verb="get"
+        ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def get(cls, id: str) -> Audience:
@@ -74,8 +81,10 @@ class Audiences:
             Audience: The audience object
         """
         path = f"/audiences/{id}"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(Audience, resp)
+        resp = request.Request[Audience](path=path, params={}, verb="get").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def remove(cls, id: str) -> Audience:
@@ -90,5 +99,7 @@ class Audiences:
             Audience: The audience object
         """
         path = f"/audiences/{id}"
-        resp = request.Request(path=path, params={}, verb="delete").perform()
-        return cast(Audience, resp)
+        resp = request.Request[Audience](path=path, params={}, verb="delete").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -46,9 +46,7 @@ class Audiences:
         path = "/audiences"
         resp = request.Request[Audience](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -63,9 +61,7 @@ class Audiences:
         path = "/audiences/"
         resp = request.Request[_ListResponse](
             path=path, params={}, verb="get"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -81,9 +77,9 @@ class Audiences:
             Audience: The audience object
         """
         path = f"/audiences/{id}"
-        resp = request.Request[Audience](path=path, params={}, verb="get").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Audience](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -99,7 +95,7 @@ class Audiences:
             Audience: The audience object
         """
         path = f"/audiences/{id}"
-        resp = request.Request[Audience](path=path, params={}, verb="delete").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Audience](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
         return resp

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, cast
 from typing_extensions import NotRequired, TypedDict
 
 from resend import request
-from resend.exceptions import NoContentError
 
 from ._contact import Contact
 

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -88,9 +88,7 @@ class Contacts:
         path = f"/audiences/{params['audience_id']}/contacts"
         resp = request.Request[Contact](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -108,9 +106,7 @@ class Contacts:
         path = f"/audiences/{params['audience_id']}/contacts/{params['id']}"
         resp = request.Request[Contact](
             path=path, params=cast(Dict[Any, Any], params), verb="patch"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -128,9 +124,7 @@ class Contacts:
         path = f"/audiences/{audience_id}/contacts"
         resp = request.Request[_ListResponse](
             path=path, params={}, verb="get"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -147,9 +141,9 @@ class Contacts:
             Contact: The contact object
         """
         path = f"/audiences/{audience_id}/contacts/{id}"
-        resp = request.Request[Contact](path=path, params={}, verb="get").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Contact](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -171,7 +165,7 @@ class Contacts:
             raise ValueError("id or email must be provided")
         path = f"/audiences/{audience_id}/contacts/{contact}"
 
-        resp = request.Request[Contact](path=path, params={}, verb="delete").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Contact](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
         return resp

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, cast
 from typing_extensions import NotRequired, TypedDict
 
 from resend import request
+from resend.exceptions import NoContentError
 
 from ._contact import Contact
 
@@ -85,10 +86,12 @@ class Contacts:
             Contact: The new contact object
         """
         path = f"/audiences/{params['audience_id']}/contacts"
-        resp = request.Request(
+        resp = request.Request[Contact](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform()
-        return cast(Contact, resp)
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def update(cls, params: UpdateParams) -> Contact:
@@ -103,10 +106,12 @@ class Contacts:
             Contact: The updated contact object
         """
         path = f"/audiences/{params['audience_id']}/contacts/{params['id']}"
-        resp = request.Request(
+        resp = request.Request[Contact](
             path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform()
-        return cast(Contact, resp)
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def list(cls, audience_id: str) -> ListResponse:
@@ -121,8 +126,12 @@ class Contacts:
             ListResponse: A list of contact objects
         """
         path = f"/audiences/{audience_id}/contacts"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(_ListResponse, resp)
+        resp = request.Request[_ListResponse](
+            path=path, params={}, verb="get"
+        ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def get(cls, id: str, audience_id: str) -> Contact:
@@ -138,8 +147,10 @@ class Contacts:
             Contact: The contact object
         """
         path = f"/audiences/{audience_id}/contacts/{id}"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(Contact, resp)
+        resp = request.Request[Contact](path=path, params={}, verb="get").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def remove(cls, audience_id: str, id: str = "", email: str = "") -> Contact:
@@ -160,5 +171,7 @@ class Contacts:
             raise ValueError("id or email must be provided")
         path = f"/audiences/{audience_id}/contacts/{contact}"
 
-        resp = request.Request(path=path, params={}, verb="delete").perform()
-        return cast(Contact, resp)
+        resp = request.Request[Contact](path=path, params={}, verb="delete").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp

--- a/resend/domains/_domains.py
+++ b/resend/domains/_domains.py
@@ -4,6 +4,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.domains._domain import Domain
+from resend.exceptions import NoContentError
 
 
 class _ListResponse(TypedDict):
@@ -61,10 +62,12 @@ class Domains:
             Domain: The new domain object
         """
         path = "/domains"
-        resp = request.Request(
+        resp = request.Request[Domain](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform()
-        return cast(Domain, resp)
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def update(cls, params: UpdateParams) -> Domain:
@@ -79,10 +82,12 @@ class Domains:
             Domain: The updated domain object
         """
         path = f"/domains/{params['id']}"
-        resp = request.Request(
+        resp = request.Request[Domain](
             path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform()
-        return cast(Domain, resp)
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def get(cls, domain_id: str) -> Domain:
@@ -97,8 +102,10 @@ class Domains:
             Domain: The domain object
         """
         path = f"/domains/{domain_id}"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(Domain, resp)
+        resp = request.Request[Domain](path=path, params={}, verb="get").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def list(cls) -> ListResponse:
@@ -110,8 +117,12 @@ class Domains:
             ListResponse: A list of domain objects
         """
         path = "/domains"
-        resp = request.Request(path=path, params={}, verb="get").perform()
-        return cast(_ListResponse, resp)
+        resp = request.Request[_ListResponse](
+            path=path, params={}, verb="get"
+        ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def remove(cls, domain_id: str) -> Domain:
@@ -126,8 +137,10 @@ class Domains:
             Domain: The removed domain object
         """
         path = f"/domains/{domain_id}"
-        resp = request.Request(path=path, params={}, verb="delete").perform()
-        return cast(Domain, resp)
+        resp = request.Request[Domain](path=path, params={}, verb="delete").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def verify(cls, domain_id: str) -> Domain:
@@ -142,5 +155,7 @@ class Domains:
             Domain: The verified domain object
         """
         path = f"/domains/{domain_id}/verify"
-        resp = request.Request(path=path, params={}, verb="post").perform()
-        return cast(Domain, resp)
+        resp = request.Request[Domain](path=path, params={}, verb="post").perform()
+        if resp is None:
+            raise NoContentError()
+        return resp

--- a/resend/domains/_domains.py
+++ b/resend/domains/_domains.py
@@ -4,7 +4,6 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.domains._domain import Domain
-from resend.exceptions import NoContentError
 
 
 class _ListResponse(TypedDict):

--- a/resend/domains/_domains.py
+++ b/resend/domains/_domains.py
@@ -64,9 +64,7 @@ class Domains:
         path = "/domains"
         resp = request.Request[Domain](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -84,9 +82,7 @@ class Domains:
         path = f"/domains/{params['id']}"
         resp = request.Request[Domain](
             path=path, params=cast(Dict[Any, Any], params), verb="patch"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -102,9 +98,9 @@ class Domains:
             Domain: The domain object
         """
         path = f"/domains/{domain_id}"
-        resp = request.Request[Domain](path=path, params={}, verb="get").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Domain](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -119,9 +115,7 @@ class Domains:
         path = "/domains"
         resp = request.Request[_ListResponse](
             path=path, params={}, verb="get"
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -137,9 +131,9 @@ class Domains:
             Domain: The removed domain object
         """
         path = f"/domains/{domain_id}"
-        resp = request.Request[Domain](path=path, params={}, verb="delete").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Domain](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -155,7 +149,7 @@ class Domains:
             Domain: The verified domain object
         """
         path = f"/domains/{domain_id}/verify"
-        resp = request.Request[Domain](path=path, params={}, verb="post").perform()
-        if resp is None:
-            raise NoContentError()
+        resp = request.Request[Domain](
+            path=path, params={}, verb="post"
+        ).perform_with_content()
         return resp

--- a/resend/emails/_batch.py
+++ b/resend/emails/_batch.py
@@ -39,9 +39,7 @@ class Batch:
         """
         path = "/emails/batch"
 
-        return cast(
-            _SendResponse,
-            request.Request(
-                path=path, params=cast(List[Dict[Any, Any]], params), verb="post"
-            ).perform(),
-        )
+        resp = request.Request[_SendResponse](
+            path=path, params=cast(List[Dict[Any, Any]], params), verb="post"
+        ).perform_with_content()
+        return resp

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -6,6 +6,7 @@ from resend import request
 from resend.emails._attachment import Attachment
 from resend.emails._email import Email
 from resend.emails._tag import Tag
+from resend.exceptions import NoContentError
 
 # SendParamsFrom is declared with functional TypedDict syntax here because
 # "from" is a reserved keyword in Python, and this is the best way to
@@ -92,13 +93,14 @@ class Emails:
             Email: The email object that was sent
         """
         path = "/emails"
-
-        return cast(
-            Email,
-            request.Request(
-                path=path, params=cast(Dict[Any, Any], params), verb="post"
-            ).perform(),
-        )
+        resp = request.Request[Email](
+            path=path,
+            params=cast(Dict[Any, Any], params),
+            verb="post",
+        ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     @classmethod
     def get(cls, email_id: str) -> Email:
@@ -113,4 +115,11 @@ class Emails:
             Email: The email object that was retrieved
         """
         path = f"/emails/{email_id}"
-        return cast(Email, request.Request(path=path, params={}, verb="get").perform())
+        resp = request.Request[Email](
+            path=path,
+            params={},
+            verb="get",
+        ).perform()
+        if resp is None:
+            raise NoContentError()
+        return resp

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -6,7 +6,6 @@ from resend import request
 from resend.emails._attachment import Attachment
 from resend.emails._email import Email
 from resend.emails._tag import Tag
-from resend.exceptions import NoContentError
 
 # SendParamsFrom is declared with functional TypedDict syntax here because
 # "from" is a reserved keyword in Python, and this is the best way to

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -97,9 +97,7 @@ class Emails:
             path=path,
             params=cast(Dict[Any, Any], params),
             verb="post",
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp
 
     @classmethod
@@ -119,7 +117,5 @@ class Emails:
             path=path,
             params={},
             verb="get",
-        ).perform()
-        if resp is None:
-            raise NoContentError()
+        ).perform_with_content()
         return resp

--- a/resend/exceptions.py
+++ b/resend/exceptions.py
@@ -225,7 +225,6 @@ class NoContentError(Exception):
     """Raised when the response body is empty."""
 
     def __init__(self) -> None:
-        self.message = (
-            "No content was returned from the API.\nPlease contact Resend support."
-        )
+        self.message = """No content was returned from the API.
+            Please contact Resend support."""
         Exception.__init__(self, self.message)

--- a/resend/exceptions.py
+++ b/resend/exceptions.py
@@ -219,3 +219,13 @@ def raise_for_code_and_type(
     raise ResendError(
         code=code, message=message, error_type=error_type, suggested_action=""
     )
+
+
+class NoContentError(Exception):
+    """Raised when the response body is empty."""
+
+    def __init__(self) -> None:
+        self.message = (
+            "No content was returned from the API.\nPlease contact Resend support."
+        )
+        Exception.__init__(self, self.message)

--- a/resend/request.py
+++ b/resend/request.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, Union, cast
+from typing import Any, Dict, List, Union, cast
 
 import requests
 from typing_extensions import Generic, Literal, TypeVar

--- a/resend/request.py
+++ b/resend/request.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, Union, cast
 
 import requests
-from typing_extensions import Literal
+from typing_extensions import Generic, Literal, TypeVar
 
 import resend
 from resend.exceptions import raise_for_code_and_type
@@ -9,9 +9,11 @@ from resend.version import get_version
 
 RequestVerb = Literal["get", "post", "put", "patch", "delete"]
 
+T = TypeVar("T")
+
 
 # This class wraps the HTTP request creation logic
-class Request:
+class Request(Generic[T]):
     def __init__(
         self,
         path: str,
@@ -22,7 +24,7 @@ class Request:
         self.params = params
         self.verb = verb
 
-    def perform(self) -> Any:
+    def perform(self) -> Union[T, None]:
         """Is the main function that makes the HTTP request
         to the Resend API. It uses the path, params, and verb attributes
         to make the request.
@@ -47,7 +49,7 @@ class Request:
                 message=error.get("message"),
                 error_type=error.get("name"),
             )
-        return resp.json()
+        return cast(T, resp.json())
 
     def __get_headers(self) -> Dict[Any, Any]:
         """get_headers returns the HTTP headers that will be

--- a/resend/request.py
+++ b/resend/request.py
@@ -4,7 +4,7 @@ import requests
 from typing_extensions import Literal, TypeVar
 
 import resend
-from resend.exceptions import raise_for_code_and_type
+from resend.exceptions import NoContentError, raise_for_code_and_type
 from resend.version import get_version
 
 RequestVerb = Literal["get", "post", "put", "patch", "delete"]
@@ -30,7 +30,7 @@ class Request(Generic[T]):
         to make the request.
 
         Returns:
-            Dict: The JSON response from the API
+            Union[T, None]: A generic type of the Request class or None
 
         Raises:
             requests.HTTPError: If the request fails
@@ -50,6 +50,25 @@ class Request(Generic[T]):
                 error_type=error.get("name"),
             )
         return cast(T, resp.json())
+
+    def perform_with_content(self) -> T:
+        """
+        Perform an HTTP request and return the response content.
+
+        This method sends an HTTP request to the specified path with the given parameters
+        and HTTP verb. It uses the generic type `T` to specify the expected type of the
+        response content. If the response content is `None`, it raises a `NoContentError`.
+
+        Returns:
+            T: The content of the response, cast to the specified type `T`.
+
+        Raises:
+            NoContentError: If the response content is `None`.
+        """
+        resp = self.perform()
+        if resp is None:
+            raise NoContentError()
+        return resp
 
     def __get_headers(self) -> Dict[Any, Any]:
         """get_headers returns the HTTP headers that will be

--- a/resend/request.py
+++ b/resend/request.py
@@ -55,12 +55,8 @@ class Request(Generic[T]):
         """
         Perform an HTTP request and return the response content.
 
-        This method sends an HTTP request to the specified path with the given parameters
-        and HTTP verb. It uses the generic type `T` to specify the expected type of the
-        response content. If the response content is `None`, it raises a `NoContentError`.
-
         Returns:
-            T: The content of the response, cast to the specified type `T`.
+            T: The content of the response
 
         Raises:
             NoContentError: If the response content is `None`.

--- a/resend/request.py
+++ b/resend/request.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, Generic, List, Union, cast
 
 import requests
-from typing_extensions import Generic, Literal, TypeVar
+from typing_extensions import Literal, TypeVar
 
 import resend
 from resend.exceptions import raise_for_code_and_type

--- a/tests/api_keys_test.py
+++ b/tests/api_keys_test.py
@@ -1,4 +1,5 @@
 import resend
+from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -19,6 +20,14 @@ class TestResendApiKeys(ResendBaseTest):
         key: resend.ApiKey = resend.ApiKeys.create(params)
         assert key["id"] == "dacf4072-4119-4d88-932f-6202748ac7c8"
 
+    def test_should_create_api_key_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.ApiKeys.CreateParams = {
+            "name": "prod",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.ApiKeys.create(params)
+
     def test_api_keys_list(self) -> None:
         self.set_mock_json(
             {
@@ -37,6 +46,11 @@ class TestResendApiKeys(ResendBaseTest):
             assert key["id"] == "91f3200a-df72-4654-b0cd-f202395f5354"
             assert key["name"] == "Production"
             assert key["created_at"] == "2023-04-08T00:11:13.110779+00:00"
+
+    def test_should_list_api_key_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.ApiKeys.list()
 
     def test_api_keys_remove(self) -> None:
         self.set_mock_text("")

--- a/tests/audiences_test.py
+++ b/tests/audiences_test.py
@@ -1,4 +1,5 @@
 import resend
+from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -21,6 +22,14 @@ class TestResendAudiences(ResendBaseTest):
         assert audience["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
         assert audience["name"] == "Registered Users"
 
+    def test_should_create_audiences_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Audiences.CreateParams = {
+            "name": "Python SDK Audience",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Audiences.create(params)
+
     def test_audiences_get(self) -> None:
         self.set_mock_json(
             {
@@ -36,6 +45,11 @@ class TestResendAudiences(ResendBaseTest):
         assert audience["name"] == "Registered Users"
         assert audience["created_at"] == "2023-10-06T22:59:55.977Z"
 
+    def test_should_get_audiences_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Audiences.get(id="78261eea-8f8b-4381-83c6-79fa7120f1cf")
+
     def test_audiences_remove(self) -> None:
         self.set_mock_json(
             {
@@ -48,6 +62,11 @@ class TestResendAudiences(ResendBaseTest):
         rmed = resend.Audiences.remove("78261eea-8f8b-4381-83c6-79fa7120f1cf")
         assert rmed["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
         assert rmed["deleted"] is True
+
+    def test_should_remove_audiences_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Audiences.remove(id="78261eea-8f8b-4381-83c6-79fa7120f1cf")
 
     def test_audiences_list(self) -> None:
         self.set_mock_json(
@@ -66,3 +85,8 @@ class TestResendAudiences(ResendBaseTest):
         audiences: resend.Audiences.ListResponse = resend.Audiences.list()
         assert audiences["data"][0]["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
         assert audiences["data"][0]["name"] == "Registered Users"
+
+    def test_should_list_audiences_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Audiences.list()

--- a/tests/batch_emails_test.py
+++ b/tests/batch_emails_test.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import resend
+from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -36,3 +37,22 @@ class TestResendBatchSend(ResendBaseTest):
         assert len(emails["data"]) == 2
         assert emails["data"][0]["id"] == "ae2014de-c168-4c61-8267-70d2662a1ce1"
         assert emails["data"][1]["id"] == "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb"
+
+    def test_should_send_batch_email_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: List[resend.Emails.SendParams] = [
+            {
+                "from": "from@resend.dev",
+                "to": ["to@resend.dev"],
+                "subject": "hey",
+                "html": "<strong>hello, world!</strong>",
+            },
+            {
+                "from": "from@resend.dev",
+                "to": ["to@resend.dev"],
+                "subject": "hello",
+                "html": "<strong>hello, world!</strong>",
+            },
+        ]
+        with self.assertRaises(NoContentError):
+            _ = resend.Batch.send(params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -21,7 +21,7 @@ class ResendBaseTest(TestCase):
     def tearDown(self) -> None:
         self.patcher.stop()
 
-    def set_mock_json(self, mock_json: Dict[Any, Any]) -> None:
+    def set_mock_json(self, mock_json: Any) -> None:
         """Auxiliary function to set the mock json return value"""
         self.m.json = lambda: mock_json
 

--- a/tests/contacts_test.py
+++ b/tests/contacts_test.py
@@ -1,4 +1,5 @@
 import resend
+from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -20,6 +21,18 @@ class TestResendContacts(ResendBaseTest):
         contact: resend.Contact = resend.Contacts.create(params)
         assert contact["id"] == "479e3145-dd38-476b-932c-529ceb705947"
 
+    def test_should_create_contacts_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Contacts.CreateParams = {
+            "audience_id": "48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
+            "email": "steve.wozniak@gmail.com",
+            "first_name": "Steve",
+            "last_name": "Wozniak",
+            "unsubscribed": True,
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.create(params)
+
     def test_contacts_update(self) -> None:
         self.set_mock_json(
             {
@@ -36,6 +49,17 @@ class TestResendContacts(ResendBaseTest):
         }
         contact = resend.Contacts.update(params)
         assert contact["id"] == "479e3145-dd38-476b-932c-529ceb705947"
+
+    def test_should_update_contacts_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Contacts.UpdateParams = {
+            "audience_id": "48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
+            "id": "479e3145-dd38-476b-932c-529ceb705947",
+            "first_name": "Updated",
+            "unsubscribed": True,
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.update(params)
 
     def test_contacts_get(self) -> None:
         self.set_mock_json(
@@ -61,6 +85,14 @@ class TestResendContacts(ResendBaseTest):
         assert contact["created_at"] == "2023-10-06T23:47:56.678Z"
         assert contact["unsubscribed"] is False
 
+    def test_should_get_contacts_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.get(
+                id="e169aa45-1ecf-4183-9955-b1499d5701d3",
+                audience_id="48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
+            )
+
     def test_contacts_remove_by_id(self) -> None:
         self.set_mock_json(
             {
@@ -77,6 +109,14 @@ class TestResendContacts(ResendBaseTest):
         assert rmed["id"] == "520784e2-887d-4c25-b53c-4ad46ad38100"
         assert rmed["deleted"] is True
 
+    def test_should_remove_contacts_by_id_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.remove(
+                audience_id="48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
+                id="78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            )
+
     def test_contacts_remove_by_email(self) -> None:
         self.set_mock_json(
             {
@@ -92,6 +132,16 @@ class TestResendContacts(ResendBaseTest):
         )
         assert rmed["id"] == "520784e2-887d-4c25-b53c-4ad46ad38100"
         assert rmed["deleted"] is True
+
+    def test_should_remove_contacts_by_email_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.remove(
+                audience_id="48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
+                email="someemail@email.com",
+            )
 
     def test_contacts_remove_raises(self) -> None:
         resend.api_key = "re_123"
@@ -129,3 +179,8 @@ class TestResendContacts(ResendBaseTest):
         assert contacts["data"][0]["last_name"] == "Wozniak"
         assert contacts["data"][0]["created_at"] == "2023-10-06T23:47:56.678Z"
         assert contacts["data"][0]["unsubscribed"] is False
+
+    def test_should_list_contacts_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.list(audience_id="48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8")

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -1,4 +1,5 @@
 import resend
+from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -69,6 +70,14 @@ class TestResendDomains(ResendBaseTest):
         assert domain["created_at"] == "2023-03-28T17:12:02.059593+00:00"
         assert domain["region"] == "us-east-1"
 
+    def test_should_create_domains_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        create_params: resend.Domains.CreateParams = {
+            "name": "example.com",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Domains.create(params=create_params)
+
     def test_domains_get(self) -> None:
         self.set_mock_json(
             {
@@ -89,6 +98,13 @@ class TestResendDomains(ResendBaseTest):
         assert domain["status"] == "not_started"
         assert domain["created_at"] == "2023-04-26T20:21:26.347412+00:00"
         assert domain["region"] == "us-east-1"
+
+    def test_should_get_domains_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Domains.get(
+                domain_id="d91cd9bd-1176-453e-8fc1-35364d380206",
+            )
 
     def test_domains_list(self) -> None:
         self.set_mock_json(
@@ -112,6 +128,11 @@ class TestResendDomains(ResendBaseTest):
         assert domains["data"][0]["created_at"] == "2023-04-26T20:21:26.347412+00:00"
         assert domains["data"][0]["region"] == "us-east-1"
 
+    def test_should_list_domains_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Domains.list()
+
     def test_domains_remove(self) -> None:
         self.set_mock_json(
             {
@@ -127,6 +148,13 @@ class TestResendDomains(ResendBaseTest):
         assert domain["deleted"] is True
         assert domain["id"] == "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
 
+    def test_should_remove_domains_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Domains.remove(
+                domain_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            )
+
     def test_domains_verify(self) -> None:
         self.set_mock_json(
             {"object": "domain", "id": "d91cd9bd-1176-453e-8fc1-35364d380206"}
@@ -136,6 +164,13 @@ class TestResendDomains(ResendBaseTest):
             domain_id="d91cd9bd-1176-453e-8fc1-35364d380206",
         )
         assert domain["id"] == "d91cd9bd-1176-453e-8fc1-35364d380206"
+
+    def test_should_verify_domains_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Domains.verify(
+                domain_id="d91cd9bd-1176-453e-8fc1-35364d380206",
+            )
 
     def test_domains_update(self) -> None:
         self.set_mock_json(
@@ -152,3 +187,13 @@ class TestResendDomains(ResendBaseTest):
         }
         domain = resend.Domains.update(params)
         assert domain["id"] == "479e3145-dd38-476b-932c-529ceb705947"
+
+    def test_should_update_domains_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Domains.UpdateParams = {
+            "id": "479e3145-dd38-476b-932c-529ceb705947",
+            "open_tracking": True,
+            "click_tracking": True,
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Domains.update(params)

--- a/tests/emails_test.py
+++ b/tests/emails_test.py
@@ -1,4 +1,5 @@
 import resend
+from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -12,7 +13,6 @@ class TestResendEmail(ResendBaseTest):
                 "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
             }
         )
-
         params: resend.Emails.SendParams = {
             "to": "to@email.com",
             "from": "from@email.com",
@@ -21,6 +21,17 @@ class TestResendEmail(ResendBaseTest):
         }
         email: resend.Email = resend.Emails.send(params)
         assert email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+
+    def test_should_send_email_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Emails.SendParams = {
+            "to": "to@email.com",
+            "from": "from@email.com",
+            "subject": "subject",
+            "html": "html",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Emails.send(params)
 
     def test_email_get(self) -> None:
         self.set_mock_json(
@@ -44,3 +55,10 @@ class TestResendEmail(ResendBaseTest):
             email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
         )
         assert email["id"] == "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+
+    def test_should_get_email_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Emails.get(
+                email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            )


### PR DESCRIPTION
Implementing [Generics](https://docs.python.org/3/library/typing.html#generics) type hint to avoid using "Any".

The main purpose of this PR is to avoid using "Any" inside `Request.perform()`

Now Request class is a Generic class `Request(Generic[T])`, with that we can mark the `perform` method to return a specific type.
#### Example:
For this example
So Request[Email] will return an Email type
```python
request.Request[Email]
```
And we can make sure the `resp` variable is an Email
```python
resp = request.Request[Email](
            path=path,
            params=cast(Dict[Any, Any], params),
            verb="post",
        ).perform_with_content()
```
Because `perform_with_content` is returning a generic type `T`
```python
def perform_with_content(self) -> T:
    ...
```

--- 

`perform_with_content` is a method the wrap `perform` method to check if the return is not None and we can make sure the return type is a generic `T`

---

So after that we can work to include right types to return and fix this issue: #105 