### PR TITLE
update requirements - typing_extensions should be at least 4.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.31.0
-typing_extensions
+typing_extensions>=4.4.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     python_requires=">=3.7",
     keywords=["email", "email platform"],
     classifiers=[
-        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",


### PR DESCRIPTION
The SDK throws exceptions when there is a previously installed `typing_extensions` that is older than `4.4.0` on the user's machine. Updating it manually fix the issue, but this PR should pin the version to `>=4.4.0`

Should fix: https://github.com/resend/resend-python/issues/119