### PR TITLE
chore: version bump v2.5.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.0"
+__version__ = "2.5.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
I accidentally jumped to v2.6.0