### PR TITLE
feat: Add support for custom http clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 RUN pip install tox
+RUN pip install setuptools==68.2.2
+RUN pip install wheel
 
 ENV APP_HOME /app
 

--- a/examples/with_custom_http_client.py
+++ b/examples/with_custom_http_client.py
@@ -1,0 +1,62 @@
+import os
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+
+import requests
+
+import resend
+from resend.http_client import HTTPClient
+
+if not os.environ["RESEND_API_KEY"]:
+    raise EnvironmentError("RESEND_API_KEY is missing")
+
+
+# Define a custom HTTP client using the requests library with a higher timeout val
+class CustomRequestsClient(HTTPClient):
+    def __init__(self, timeout: int = 300):
+        self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        json: Optional[Union[Dict[str, Any], List[Any]]] = None,
+    ) -> Tuple[bytes, int, Dict[str, str]]:
+        print(f"[HTTP] {method.upper()} {url} with timeout={self.timeout}")
+        try:
+            response = requests.request(
+                method=method,
+                url=url,
+                headers=headers,
+                json=json,
+                timeout=self.timeout,
+            )
+            return (
+                response.content,
+                response.status_code,
+                dict(response.headers),
+            )
+        except requests.RequestException as e:
+            raise RuntimeError(f"HTTP request failed: {e}") from e
+
+
+# use the custom HTTP client with a longer timeout
+resend.default_http_client = CustomRequestsClient(timeout=400)
+
+params: resend.Emails.SendParams = {
+    "from": "onboarding@resend.dev",
+    "to": ["delivered@resend.dev"],
+    "subject": "hi",
+    "html": "<strong>hello, world!</strong>",
+    "reply_to": "to@gmail.com",
+    "bcc": "delivered@resend.dev",
+    "cc": ["delivered@resend.dev"],
+    "tags": [
+        {"name": "tag1", "value": "tagvalue1"},
+        {"name": "tag2", "value": "tagvalue2"},
+    ],
+}
+
+
+email: resend.Email = resend.Emails.send(params)
+print(f"{email}")

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -15,12 +15,17 @@ from .emails._batch import Batch
 from .emails._email import Email
 from .emails._emails import Emails
 from .emails._tag import Tag
+from .http_client import HTTPClient
+from .http_client_requests import RequestsClient
 from .request import Request
 from .version import __version__, get_version
 
 # Config vars
 api_key = os.environ.get("RESEND_API_KEY")
 api_url = os.environ.get("RESEND_API_URL", "https://api.resend.com")
+
+# HTTP Client
+default_http_client: HTTPClient = RequestsClient()
 
 # API resources
 from .emails._emails import Emails  # noqa

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -50,4 +50,6 @@ __all__ = [
     "Attachment",
     "Tag",
     "Broadcast",
+    # Default HTTP Client
+    "RequestsClient",
 ]

--- a/resend/exceptions.py
+++ b/resend/exceptions.py
@@ -4,7 +4,7 @@ This module defines the base types for platform-wide error
 codes as outlined in https://resend.com/docs/api-reference/errors.
 """
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, NoReturn, Union
 
 
 class ResendError(Exception):
@@ -175,7 +175,7 @@ ERRORS: Dict[str, Dict[str, Any]] = {
 
 def raise_for_code_and_type(
     code: Union[str, int], error_type: str, message: str
-) -> None:
+) -> NoReturn:
     """Raise the appropriate error based on the code and type.
 
     Args:

--- a/resend/http_client.py
+++ b/resend/http_client.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Any, Mapping, Optional, Tuple, Union
+
+
+class HTTPClient(ABC):
+    @abstractmethod
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        json: Optional[Union[dict, list]] = None,
+    ) -> Tuple[bytes, int, Mapping[str, str]]:
+        pass

--- a/resend/http_client.py
+++ b/resend/http_client.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Tuple, Union, List
 
 
 class HTTPClient(ABC):
@@ -9,6 +9,6 @@ class HTTPClient(ABC):
         method: str,
         url: str,
         headers: Mapping[str, str],
-        json: Optional[Union[dict[str, object], list[object]]] = None,
+        json: Optional[Union[dict[str, object], List[object]]] = None,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         pass

--- a/resend/http_client.py
+++ b/resend/http_client.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Tuple, Union
 
 
 class HTTPClient(ABC):
@@ -9,6 +9,6 @@ class HTTPClient(ABC):
         method: str,
         url: str,
         headers: Mapping[str, str],
-        json: Optional[Union[dict, list]] = None,
+        json: Optional[Union[dict[str, object], list[object]]] = None,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         pass

--- a/resend/http_client.py
+++ b/resend/http_client.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional, Tuple, Union, List
+from typing import Mapping, Optional, Tuple, Union, List, Dict
 
 
 class HTTPClient(ABC):
@@ -9,6 +9,6 @@ class HTTPClient(ABC):
         method: str,
         url: str,
         headers: Mapping[str, str],
-        json: Optional[Union[dict[str, object], List[object]]] = None,
+        json: Optional[Union[Dict[str, object], List[object]]] = None,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         pass

--- a/resend/http_client.py
+++ b/resend/http_client.py
@@ -1,8 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional, Tuple, Union, List, Dict
+from typing import Dict, List, Mapping, Optional, Tuple, Union
 
 
 class HTTPClient(ABC):
+    """
+    Abstract base class for HTTP clients.
+    This class defines the interface for making HTTP requests.
+    Subclasses should implement the `request` method.
+    """
+
     @abstractmethod
     def request(
         self,

--- a/resend/http_client_requests.py
+++ b/resend/http_client_requests.py
@@ -1,0 +1,29 @@
+from typing import Mapping, Optional, Tuple, Union
+
+import requests
+
+from resend.http_client import HTTPClient
+
+
+class RequestsClient(HTTPClient):
+    def __init__(self, timeout: int = 30):
+        self._timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        json: Optional[Union[dict, list]] = None,
+    ) -> Tuple[bytes, int, Mapping[str, str]]:
+        try:
+            resp = requests.request(
+                method=method,
+                url=url,
+                headers=headers,
+                json=json,
+                timeout=self._timeout,
+            )
+            return resp.content, resp.status_code, resp.headers
+        except requests.RequestException as e:
+            raise RuntimeError(f"Request failed: {e}") from e

--- a/resend/http_client_requests.py
+++ b/resend/http_client_requests.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Tuple, Union, List, Dict
+from typing import Dict, List, Mapping, Optional, Tuple, Union
 
 import requests
 

--- a/resend/http_client_requests.py
+++ b/resend/http_client_requests.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Tuple, Union, List
 
 import requests
 
@@ -14,7 +14,7 @@ class RequestsClient(HTTPClient):
         method: str,
         url: str,
         headers: Mapping[str, str],
-        json: Optional[Union[dict[str, object], list[object]]] = None,
+        json: Optional[Union[dict[str, object], List[object]]] = None,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         try:
             resp = requests.request(

--- a/resend/http_client_requests.py
+++ b/resend/http_client_requests.py
@@ -14,7 +14,7 @@ class RequestsClient(HTTPClient):
         method: str,
         url: str,
         headers: Mapping[str, str],
-        json: Optional[Union[dict, list]] = None,
+        json: Optional[Union[dict[str, object], list[object]]] = None,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         try:
             resp = requests.request(

--- a/resend/http_client_requests.py
+++ b/resend/http_client_requests.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Tuple, Union, List
+from typing import Mapping, Optional, Tuple, Union, List, Dict
 
 import requests
 
@@ -14,7 +14,7 @@ class RequestsClient(HTTPClient):
         method: str,
         url: str,
         headers: Mapping[str, str],
-        json: Optional[Union[dict[str, object], List[object]]] = None,
+        json: Optional[Union[Dict[str, object], List[object]]] = None,
     ) -> Tuple[bytes, int, Mapping[str, str]]:
         try:
             resp = requests.request(

--- a/resend/http_client_requests.py
+++ b/resend/http_client_requests.py
@@ -6,6 +6,10 @@ from resend.http_client import HTTPClient
 
 
 class RequestsClient(HTTPClient):
+    """
+    This is the default HTTP client implementation using the requests library.
+    """
+
     def __init__(self, timeout: int = 30):
         self._timeout = timeout
 
@@ -26,4 +30,6 @@ class RequestsClient(HTTPClient):
             )
             return resp.content, resp.status_code, resp.headers
         except requests.RequestException as e:
+            # This gets caught by the request.perform() method
+            # and raises a ResendError with the error type "HttpClientError"
             raise RuntimeError(f"Request failed: {e}") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import resend
 class ResendBaseTest(TestCase):
     def setUp(self) -> None:
         resend.api_key = "re_123"
+        resend.default_http_client = resend.RequestsClient()
         self.patcher = patch("resend.request.Request.make_request")
         self.mock = self.patcher.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,25 +10,19 @@ import resend
 class ResendBaseTest(TestCase):
     def setUp(self) -> None:
         resend.api_key = "re_123"
-
-        self.patcher = patch("resend.Request.make_request")
+        self.patcher = patch("resend.request.Request.make_request")
         self.mock = self.patcher.start()
-        self.m = MagicMock(
-            status_code=200,
-            headers={"content-type": "application/json; charset=utf-8"},
-        )
-        self.mock.return_value = self.m
 
     def tearDown(self) -> None:
         self.patcher.stop()
 
     def set_mock_json(self, mock_json: Any) -> None:
         """Auxiliary function to set the mock json return value"""
-        self.m.json = lambda: mock_json
+        self.mock.return_value = mock_json
 
     def set_mock_text(self, mock_text: str) -> None:
         """Auxiliary function to set the mock text return value"""
-        self.m.text = mock_text
+        self.mock.text = mock_text
 
     def set_magic_mock_obj(self, magic_mock_obj: MagicMock) -> None:
         """Auxiliary function to set the mock object"""

--- a/tests/default_http_client_test.py
+++ b/tests/default_http_client_test.py
@@ -1,0 +1,42 @@
+from typing import cast
+from unittest import TestCase
+from unittest.mock import create_autospec
+
+import resend
+from resend.http_client import HTTPClient
+
+
+class TestDefaultHttpClientUsage(TestCase):
+    def setUp(self) -> None:
+        resend.api_key = "re_test"
+        resend.default_http_client = cast(HTTPClient, None)
+
+    def tearDown(self) -> None:
+        resend.api_key = None
+        resend.default_http_client = cast(HTTPClient, None)
+
+    def test_default_http_client_called_with_correct_payload(self) -> None:
+        mock_client = create_autospec(HTTPClient, instance=True)
+        mock_client.name = "mock"
+        mock_client.request.return_value = (
+            b'{"id": "email_123"}',
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+        resend.default_http_client = mock_client
+
+        resend.Emails.send(
+            {
+                "from": "hello@example.com",
+                "to": ["world@example.com"],
+                "subject": "Hi!",
+                "html": "<b>hi</b>",
+            }
+        )
+
+        mock_client.request.assert_called_once()
+        args, kwargs = mock_client.request.call_args
+        assert kwargs["method"] == "post"
+        assert "/emails" in kwargs["url"]
+        assert kwargs["json"]["subject"] == "Hi!"

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -7,13 +7,13 @@ from resend.version import get_version
 
 
 class TestResendRequest(unittest.TestCase):
-    @patch("resend.request.requests.request")
+    @patch("resend.http_client_requests.requests.request")
     @patch("resend.api_key", new="test_key")
     def test_request_idempotency_key_is_set(self, mock_requests: MagicMock) -> None:
         mock_response = Mock()
-        mock_response.text = "{}"
+        mock_response.content = b"{}"
         mock_response.status_code = 200
-        mock_response.headers = {"content-type": "application/json"}
+        mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {}
 
         mock_requests.return_value = mock_response
@@ -37,11 +37,11 @@ class TestResendRequest(unittest.TestCase):
         self.assertEqual(headers["User-Agent"], f"resend-python:{get_version()}")
         self.assertEqual(headers["Idempotency-Key"], "abc-123")
 
-    @patch("resend.request.requests.request")
+    @patch("resend.http_client_requests.requests.request")
     @patch("resend.api_key", new="test_key")
     def test_request_idempotency_key_is_not_set(self, mock_requests: MagicMock) -> None:
         mock_response = Mock()
-        mock_response.text = "{}"
+        mock_response.content = b"{}"
         mock_response.status_code = 200
         mock_response.headers = {"content-type": "application/json"}
         mock_response.json.return_value = {}


### PR DESCRIPTION
Introduced a new global level attribute `default_http_client`, that can be overwritten by users to set their own HTTP Clients. Custom clients need to base off the "interface" `HTTPClient` defined in `resend/http_client.py`

Example:

```py
# resend's abstract HTTP Client class.
from resend.http_client import HTTPClient

class CustomRequestsClient(HTTPClient):
    def __init__(self, timeout: int = 30):
        self.timeout = timeout

    def request(
        self,
        method: str,
        url: str,
        headers: Mapping[str, str],
        json: Optional[Union[Dict[str, Any], List[Any]]] = None,
    ) -> Tuple[bytes, int, Dict[str, str]]:
        print(f"[HTTP] {method.upper()} {url} with timeout={self.timeout}")
        try:
            response = requests.request(
                method=method,
                url=url,
                headers=headers,
                json=json,
                timeout=self.timeout,
            )
            return (
                response.content,
                response.status_code,
                dict(response.headers),
            )
        except requests.RequestException as e:
            raise RuntimeError(f"HTTP request failed: {e}") from e


resend.api_key = "re_123"
resend.default_http_client = CustomRequestsClient(timeout=400)

email: resend.Email = resend.Emails.send({...})
```

closes #145 