### PR TITLE
fix: wrong return types for creation methods

### DIFF
--- a/examples/api_keys.py
+++ b/examples/api_keys.py
@@ -10,7 +10,7 @@ create_params: resend.ApiKeys.CreateParams = {
     "name": "example.com",
 }
 
-key: resend.ApiKey = resend.ApiKeys.create(params=create_params)
+key: resend.ApiKeys.CreateApiKeyResponse = resend.ApiKeys.create(params=create_params)
 print("Created new api key")
 print(f"Key id: {key['id']} and token: {key['token']}")
 

--- a/examples/api_keys.py
+++ b/examples/api_keys.py
@@ -10,9 +10,11 @@ create_params: resend.ApiKeys.CreateParams = {
     "name": "example.com",
 }
 
-key: resend.ApiKeys.CreateApiKeyResponse = resend.ApiKeys.create(params=create_params)
+created_key: resend.ApiKeys.CreateApiKeyResponse = resend.ApiKeys.create(
+    params=create_params
+)
 print("Created new api key")
-print(f"Key id: {key['id']} and token: {key['token']}")
+print(f"Key id: {created_key['id']} and token: {created_key['token']}")
 
 keys: resend.ApiKeys.ListResponse = resend.ApiKeys.list()
 for key in keys["data"]:
@@ -20,5 +22,5 @@ for key in keys["data"]:
     print(key["name"])
     print(key["created_at"])
 
-if len(keys) > 0:
+if len(keys["data"]) > 0:
     resend.ApiKeys.remove(api_key_id=keys["data"][0]["id"])

--- a/examples/audiences.py
+++ b/examples/audiences.py
@@ -22,6 +22,8 @@ print("Retrieved audience: ", aud)
 audiences: resend.Audiences.ListResponse = resend.Audiences.list()
 print("List of audiences:", [a["id"] for a in audiences["data"]])
 
-rmed: resend.Audience = resend.Audiences.remove(id=audience["id"])
-print(f"Deleted audience")
+rmed: resend.Audiences.RemoveAudienceResponse = resend.Audiences.remove(
+    id=audience["id"]
+)
+print(f"Deleted audience with ID: {audience['id']}")
 print(rmed)

--- a/examples/audiences.py
+++ b/examples/audiences.py
@@ -10,7 +10,9 @@ if not os.environ["RESEND_API_KEY"]:
 create_params: resend.Audiences.CreateParams = {
     "name": "New Audience from Python SDK",
 }
-audience: resend.Audience = resend.Audiences.create(create_params)
+audience: resend.Audiences.CreateAudienceResponse = resend.Audiences.create(
+    create_params
+)
 print(f"Created audience: {audience['id']}")
 print(audience)
 

--- a/examples/broadcasts.py
+++ b/examples/broadcasts.py
@@ -1,8 +1,6 @@
 import os
-from typing import List
 
 import resend
-import resend.broadcasts
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
@@ -21,7 +19,7 @@ create_params: resend.Broadcasts.CreateParams = {
 }
 
 broadcast: resend.Broadcasts.CreateResponse = resend.Broadcasts.create(create_params)
-print("Created broadcast !")
+print("Created broadcast with ID: {}".format(broadcast["id"]))
 print(broadcast)
 
 update_params: resend.Broadcasts.UpdateParams = {

--- a/examples/contacts.py
+++ b/examples/contacts.py
@@ -50,10 +50,12 @@ for c in contacts["data"]:
     print(c)
 
 # remove by email
-rmed = resend.Contacts.remove(audience_id=audience_id, email=cont_by_email["email"])
+rmed: resend.Contacts.RemoveContactResponse = resend.Contacts.remove(
+    audience_id=audience_id, email=cont_by_email["email"]
+)
 
 # remove by id
-# rmed: resend.Contact = resend.Contacts.remove(audience_id=audience_id, id=cont["id"])
+# rmed: resend.Contacts.RemoveContactResponse = resend.Contacts.remove(audience_id=audience_id, id=cont["id"])
 
-print(f"Removed contact")
+print(f"Removed contact with ID: {rmed['contact']}")
 print(rmed)

--- a/examples/contacts.py
+++ b/examples/contacts.py
@@ -17,8 +17,8 @@ create_params: resend.Contacts.CreateParams = {
     "unsubscribed": False,
 }
 
-contact: resend.Contact = resend.Contacts.create(create_params)
-print("Created contact !")
+contact: resend.Contacts.CreateContactResponse = resend.Contacts.create(create_params)
+print("Created contact with ID: {}".format(contact["id"]))
 print(contact)
 
 update_params: resend.Contacts.UpdateParams = {
@@ -28,8 +28,8 @@ update_params: resend.Contacts.UpdateParams = {
     "first_name": "Steve",
 }
 
-updated: resend.Contact = resend.Contacts.update(update_params)
-print("updated contact !")
+updated: resend.Contacts.UpdateContactResponse = resend.Contacts.update(update_params)
+print("updated contact with ID: {}".format(updated["id"]))
 print(updated)
 
 cont_by_id: resend.Contact = resend.Contacts.get(
@@ -46,11 +46,11 @@ print(cont_by_email)
 
 contacts: resend.Contacts.ListResponse = resend.Contacts.list(audience_id=audience_id)
 print("List of contacts")
-for contact in contacts["data"]:
-    print(contact)
+for c in contacts["data"]:
+    print(c)
 
 # remove by email
-rmed = resend.Contacts.remove(audience_id=audience_id, email=contact["email"])
+rmed = resend.Contacts.remove(audience_id=audience_id, email=cont_by_email["email"])
 
 # remove by id
 # rmed: resend.Contact = resend.Contacts.remove(audience_id=audience_id, id=cont["id"])

--- a/examples/domains.py
+++ b/examples/domains.py
@@ -12,7 +12,9 @@ create_params: resend.Domains.CreateParams = {
     "region": "us-east-1",
     "custom_return_path": "outbound",
 }
-domain: resend.Domain = resend.Domains.create(params=create_params)
+domain: resend.Domains.CreateDomainResponse = resend.Domains.create(
+    params=create_params
+)
 print(domain)
 
 retrieved: resend.Domain = resend.Domains.get(domain_id=domain["id"])

--- a/resend/api_keys/_api_key.py
+++ b/resend/api_keys/_api_key.py
@@ -4,17 +4,13 @@ from typing_extensions import TypedDict
 class ApiKey(TypedDict):
     id: str
     """
-    The api key ID
-    """
-    token: str
-    """
-    The api key token
+    The API key ID
     """
     name: str
     """
-    The api key token
+    The API key name
     """
     created_at: str
     """
-    Api key creation date
+    The API key creation date
     """

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -6,21 +6,37 @@ from resend import request
 from resend.api_keys._api_key import ApiKey
 
 
-class _ListResponse(TypedDict):
-    data: List[ApiKey]
-    """
-    A list of API key objects
-    """
-
-
 class ApiKeys:
 
-    class ListResponse(_ListResponse):
+    class ListResponse(TypedDict):
         """
         ListResponse type that wraps a list of API key objects
 
         Attributes:
             data (List[Dict[str, Any]]): A list of API key objects
+        """
+
+        data: List[ApiKey]
+        """
+        A list of API key objects
+        """
+
+    class CreateApiKeyResponse(TypedDict):
+        """
+        CreateApiKeyResponse is the type that wraps the response of the API key that was created
+
+        Attributes:
+            id (str): The ID of the created API key
+            token (str): The token of the created API key
+        """
+
+        id: str
+        """
+        The ID of the created API key
+        """
+        token: str
+        """
+        The token of the created API key
         """
 
     class CreateParams(TypedDict):
@@ -41,7 +57,7 @@ class ApiKeys:
         """
 
     @classmethod
-    def create(cls, params: CreateParams) -> ApiKey:
+    def create(cls, params: CreateParams) -> CreateApiKeyResponse:
         """
         Add a new API key to authenticate communications with Resend.
         see more: https://resend.com/docs/api-reference/api-keys/create-api-key
@@ -50,10 +66,10 @@ class ApiKeys:
             params (CreateParams): The API key creation parameters
 
         Returns:
-            ApiKey: The new API key object
+            CreateApiKeyResponse: The created API key response with id and token
         """
         path = "/api-keys"
-        resp = request.Request[ApiKey](
+        resp = request.Request[ApiKeys.CreateApiKeyResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform_with_content()
         return resp
@@ -68,7 +84,7 @@ class ApiKeys:
             ListResponse: A list of API key objects
         """
         path = "/api-keys"
-        resp = request.Request[_ListResponse](
+        resp = request.Request[ApiKeys.ListResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -13,7 +13,7 @@ class ApiKeys:
         ListResponse type that wraps a list of API key objects
 
         Attributes:
-            data (List[Dict[str, Any]]): A list of API key objects
+            data (List[ApiKey]): A list of API key objects
         """
 
         data: List[ApiKey]

--- a/resend/audiences/_audience.py
+++ b/resend/audiences/_audience.py
@@ -14,7 +14,3 @@ class Audience(TypedDict):
     """
     The date and time the audience was created.
     """
-    deleted: bool
-    """
-    Wether the audience was deleted. Only returned on the "remove" call
-    """

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -7,21 +7,42 @@ from resend import request
 from ._audience import Audience
 
 
-class _ListResponse(TypedDict):
-    data: List[Audience]
-    """
-    A list of audience objects
-    """
-
-
 class Audiences:
 
-    class ListResponse(_ListResponse):
+    class ListResponse(TypedDict):
         """
         ListResponse type that wraps a list of audience objects
 
         Attributes:
             data (List[Audience]): A list of audience objects
+        """
+
+        data: List[Audience]
+        """
+        A list of audience objects
+        """
+
+    class CreateAudienceResponse(TypedDict):
+        """
+        CreateAudienceResponse is the type that wraps the response of the audience that was created
+
+        Attributes:
+            id (str): The ID of the created audience
+            name (str): The name of the created audience
+            created_at (str): When the audience was created
+        """
+
+        id: str
+        """
+        The ID of the created audience
+        """
+        name: str
+        """
+        The name of the created audience
+        """
+        created_at: str
+        """
+        When the audience was created
         """
 
     class CreateParams(TypedDict):
@@ -31,7 +52,7 @@ class Audiences:
         """
 
     @classmethod
-    def create(cls, params: CreateParams) -> Audience:
+    def create(cls, params: CreateParams) -> CreateAudienceResponse:
         """
         Create a list of contacts.
         see more: https://resend.com/docs/api-reference/audiences/create-audience
@@ -40,10 +61,11 @@ class Audiences:
             params (CreateParams): The audience creation parameters
 
         Returns:
-            Audience: The new audience object
+            CreateAudienceResponse: The created audience response
         """
+
         path = "/audiences"
-        resp = request.Request[Audience](
+        resp = request.Request[Audiences.CreateAudienceResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform_with_content()
         return resp
@@ -58,7 +80,7 @@ class Audiences:
             ListResponse: A list of audience objects
         """
         path = "/audiences/"
-        resp = request.Request[_ListResponse](
+        resp = request.Request[Audiences.ListResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -58,7 +58,6 @@ class Audiences:
             object (str): The object type, "audience"
             id (str): The ID of the created audience
             name (str): The name of the created audience
-            created_at (str): When the audience was created
         """
 
         object: str

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -37,9 +37,14 @@ class Audiences:
         ListResponse type that wraps a list of audience objects
 
         Attributes:
+            object (str): The object type, "list"
             data (List[Audience]): A list of audience objects
         """
 
+        object: str
+        """
+        The object type, "list"
+        """
         data: List[Audience]
         """
         A list of audience objects

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -9,6 +9,29 @@ from ._audience import Audience
 
 class Audiences:
 
+    class RemoveAudienceResponse(TypedDict):
+        """
+        RemoveAudienceResponse is the type that wraps the response of the audience that was removed
+
+        Attributes:
+            object (str): The object type, "audience"
+            id (str): The ID of the removed audience
+            deleted (bool): Whether the audience was deleted
+        """
+
+        object: str
+        """
+        The object type, "audience"
+        """
+        id: str
+        """
+        The ID of the removed audience
+        """
+        deleted: bool
+        """
+        Whether the audience was deleted
+        """
+
     class ListResponse(TypedDict):
         """
         ListResponse type that wraps a list of audience objects
@@ -105,7 +128,7 @@ class Audiences:
         return resp
 
     @classmethod
-    def remove(cls, id: str) -> Audience:
+    def remove(cls, id: str) -> RemoveAudienceResponse:
         """
         Delete a single audience.
         see more: https://resend.com/docs/api-reference/audiences/delete-audience
@@ -114,10 +137,10 @@ class Audiences:
             id (str): The audience ID
 
         Returns:
-            Audience: The audience object
+            RemoveAudienceResponse: The removed audience response
         """
         path = f"/audiences/{id}"
-        resp = request.Request[Audience](
+        resp = request.Request[Audiences.RemoveAudienceResponse](
             path=path, params={}, verb="delete"
         ).perform_with_content()
         return resp

--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -27,11 +27,16 @@ class Audiences:
         CreateAudienceResponse is the type that wraps the response of the audience that was created
 
         Attributes:
+            object (str): The object type, "audience"
             id (str): The ID of the created audience
             name (str): The name of the created audience
             created_at (str): When the audience was created
         """
 
+        object: str
+        """
+        The object type, "audience"
+        """
         id: str
         """
         The ID of the created audience
@@ -39,10 +44,6 @@ class Audiences:
         name: str
         """
         The name of the created audience
-        """
-        created_at: str
-        """
-        When the audience was created
         """
 
     class CreateParams(TypedDict):

--- a/resend/broadcasts/_broadcasts.py
+++ b/resend/broadcasts/_broadcasts.py
@@ -24,123 +24,9 @@ _UpdateParamsFrom = TypedDict(
 )
 
 
-class _CreateResponse(TypedDict):
-    id: str
-    """
-    id of the created broadcast
-    """
-
-
-class _UpdateResponse(TypedDict):
-    id: str
-    """
-    id of the updated broadcast
-    """
-
-
-class _SendResponse(_CreateResponse):
-    pass
-
-
-class _RemoveResponse(TypedDict):
-    object: str
-    """
-    object type: "broadcast"
-    """
-    id: str
-    """
-    id of the removed broadcast
-    """
-    deleted: bool
-    """
-    True if the broadcast was deleted
-    """
-
-
-class _ListResponse(TypedDict):
-    object: str
-    """
-    object type: "list"
-    """
-    data: List[Broadcast]
-    """
-    A list of broadcast objects
-    """
-
-
-class _CreateParamsDefault(_CreateParamsFrom):
-    audience_id: str
-    """
-    The ID of the audience you want to send to.
-    """
-    subject: str
-    """
-    Email subject.
-    """
-    reply_to: NotRequired[Union[List[str], str]]
-    """
-    Reply-to email address. For multiple addresses, send as an array of strings.
-    """
-    html: NotRequired[str]
-    """
-    The HTML version of the message.
-    """
-    text: NotRequired[str]
-    """
-    The text version of the message.
-    """
-    name: NotRequired[str]
-    """
-    The friendly name of the broadcast. Only used for internal reference.
-    """
-
-
-class _UpdateParamsDefault(_UpdateParamsFrom):
-    broadcast_id: str
-    """
-    The ID of the broadcast you want to update.
-    """
-    audience_id: NotRequired[str]
-    """
-    The ID of the audience you want to send to.
-    """
-    subject: NotRequired[str]
-    """
-    Email subject.
-    """
-    reply_to: NotRequired[Union[List[str], str]]
-    """
-    Reply-to email address. For multiple addresses, send as an array of strings.
-    """
-    html: NotRequired[str]
-    """
-    The HTML version of the message.
-    """
-    text: NotRequired[str]
-    """
-    The text version of the message.
-    """
-    name: NotRequired[str]
-    """
-    The friendly name of the broadcast. Only used for internal reference.
-    """
-
-
-class _SendBroadcastParams(TypedDict):
-    broadcast_id: str
-    """
-    The ID of the broadcast to send.
-    """
-    scheduled_at: NotRequired[str]
-    """
-    Schedule email to be sent later.
-    The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
-    """
-
-
 class Broadcasts:
 
-    class CreateParams(_CreateParamsDefault):
+    class CreateParams(_CreateParamsFrom):
         """CreateParams is the class that wraps the parameters for the create method.
 
         Attributes:
@@ -153,7 +39,32 @@ class Broadcasts:
             name (NotRequired[str]): The friendly name of the broadcast. Only used for internal reference.
         """
 
-    class UpdateParams(_UpdateParamsDefault):
+        audience_id: str
+        """
+        The ID of the audience you want to send to.
+        """
+        subject: str
+        """
+        Email subject.
+        """
+        reply_to: NotRequired[Union[List[str], str]]
+        """
+        Reply-to email address. For multiple addresses, send as an array of strings.
+        """
+        html: NotRequired[str]
+        """
+        The HTML version of the message.
+        """
+        text: NotRequired[str]
+        """
+        The text version of the message.
+        """
+        name: NotRequired[str]
+        """
+        The friendly name of the broadcast. Only used for internal reference.
+        """
+
+    class UpdateParams(_UpdateParamsFrom):
         """UpdateParams is the class that wraps the parameters for the update method.
 
         Attributes:
@@ -167,7 +78,36 @@ class Broadcasts:
             name (NotRequired[str]): The friendly name of the broadcast. Only used for internal reference.
         """
 
-    class SendParams(_SendBroadcastParams):
+        broadcast_id: str
+        """
+        The ID of the broadcast you want to update.
+        """
+        audience_id: NotRequired[str]
+        """
+        The ID of the audience you want to send to.
+        """
+        subject: NotRequired[str]
+        """
+        Email subject.
+        """
+        reply_to: NotRequired[Union[List[str], str]]
+        """
+        Reply-to email address. For multiple addresses, send as an array of strings.
+        """
+        html: NotRequired[str]
+        """
+        The HTML version of the message.
+        """
+        text: NotRequired[str]
+        """
+        The text version of the message.
+        """
+        name: NotRequired[str]
+        """
+        The friendly name of the broadcast. Only used for internal reference.
+        """
+
+    class SendParams(TypedDict):
         """SendParams is the class that wraps the parameters for the send method.
 
         Attributes:
@@ -176,7 +116,17 @@ class Broadcasts:
             The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
         """
 
-    class CreateResponse(_CreateResponse):
+        broadcast_id: str
+        """
+        The ID of the broadcast to send.
+        """
+        scheduled_at: NotRequired[str]
+        """
+        Schedule email to be sent later.
+        The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
+        """
+
+    class CreateResponse(TypedDict):
         """
         CreateResponse is the class that wraps the response of the create method.
 
@@ -184,7 +134,12 @@ class Broadcasts:
             id (str): id of the created broadcast
         """
 
-    class UpdateResponse(_UpdateResponse):
+        id: str
+        """
+        id of the created broadcast
+        """
+
+    class UpdateResponse(TypedDict):
         """
         UpdateResponse is the class that wraps the response of the update method.
 
@@ -192,7 +147,12 @@ class Broadcasts:
             id (str): id of the updated broadcast
         """
 
-    class SendResponse(_SendResponse):
+        id: str
+        """
+        id of the updated broadcast
+        """
+
+    class SendResponse(CreateResponse):
         """
         SendResponse is the class that wraps the response of the send method.
 
@@ -200,7 +160,7 @@ class Broadcasts:
             id (str): id of the created broadcast
         """
 
-    class ListResponse(_ListResponse):
+    class ListResponse(TypedDict):
         """
         ListResponse is the class that wraps the response of the list method.
 
@@ -209,7 +169,16 @@ class Broadcasts:
             data (List[Broadcast]): A list of broadcast objects
         """
 
-    class RemoveResponse(_RemoveResponse):
+        object: str
+        """
+        object type: "list"
+        """
+        data: List[Broadcast]
+        """
+        A list of broadcast objects
+        """
+
+    class RemoveResponse(TypedDict):
         """
         RemoveResponse is the class that wraps the response of the remove method.
 
@@ -217,6 +186,19 @@ class Broadcasts:
             object (str): object type: "broadcast"
             id (str): id of the removed broadcast
             deleted (bool): True if the broadcast was deleted
+        """
+
+        object: str
+        """
+        object type: "broadcast"
+        """
+        id: str
+        """
+        id of the removed broadcast
+        """
+        deleted: bool
+        """
+        True if the broadcast was deleted
         """
 
     @classmethod
@@ -231,8 +213,9 @@ class Broadcasts:
         Returns:
             CreateResponse: The new broadcast object response
         """
+
         path = "/broadcasts"
-        resp = request.Request[_CreateResponse](
+        resp = request.Request[Broadcasts.CreateResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform_with_content()
         return resp
@@ -249,8 +232,9 @@ class Broadcasts:
         Returns:
             UpdateResponse: The updated broadcast object response
         """
+
         path = f"/broadcasts/{params['broadcast_id']}"
-        resp = request.Request[_UpdateResponse](
+        resp = request.Request[Broadcasts.UpdateResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
@@ -267,8 +251,9 @@ class Broadcasts:
         Returns:
             SendResponse: The new broadcast object response
         """
+
         path = f"/broadcasts/{params['broadcast_id']}/send"
-        resp = request.Request[_SendResponse](
+        resp = request.Request[Broadcasts.SendResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform_with_content()
         return resp
@@ -283,7 +268,7 @@ class Broadcasts:
             ListResponse: A list of broadcast objects
         """
         path = "/broadcasts/"
-        resp = request.Request[_ListResponse](
+        resp = request.Request[Broadcasts.ListResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp
@@ -319,7 +304,7 @@ class Broadcasts:
             RemoveResponse: The remove response object
         """
         path = f"/broadcasts/{id}"
-        resp = request.Request[_RemoveResponse](
+        resp = request.Request[Broadcasts.RemoveResponse](
             path=path, params={}, verb="delete"
         ).perform_with_content()
         return resp

--- a/resend/contacts/_contact.py
+++ b/resend/contacts/_contact.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 class Contact(TypedDict):
@@ -10,11 +10,11 @@ class Contact(TypedDict):
     """
     The email of the contact.
     """
-    first_name: str
+    first_name: NotRequired[str]
     """
     The first name of the contact.
     """
-    last_name: str
+    last_name: NotRequired[str]
     """
     The last name of the contact.
     """
@@ -25,8 +25,4 @@ class Contact(TypedDict):
     unsubscribed: bool
     """
     The unsubscribed status of the contact.
-    """
-    deleted: bool
-    """
-    Wether the contact is deleted or not.
     """

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -9,14 +9,42 @@ from ._contact import Contact
 
 class Contacts:
 
+    class RemoveContactResponse(TypedDict):
+        """
+        RemoveContactResponse is the type that wraps the response of the contact that was removed
+
+        Attributes:
+            object (str): 'contact'
+            contact (str): The ID of the removed contact
+            deleted (bool): Whether the contact was deleted
+        """
+
+        object: str
+        """
+        The object type: contact
+        """
+        contact: str
+        """
+        The ID of the removed contact.
+        """
+        deleted: bool
+        """
+        Whether the contact was deleted.
+        """
+
     class ListResponse(TypedDict):
         """
         ListResponse type that wraps a list of contact objects
 
         Attributes:
+            object (str): The object type: list
             data (List[Contact]): A list of contact objects
         """
 
+        object: str
+        """
+        The object type: list
+        """
         data: List[Contact]
         """
         A list of contact objects
@@ -195,7 +223,7 @@ class Contacts:
     @classmethod
     def remove(
         cls, audience_id: str, id: Optional[str] = None, email: Optional[str] = None
-    ) -> Contact:
+    ) -> RemoveContactResponse:
         """
         Remove a contact by ID or by Email
         see more: https://resend.com/docs/api-reference/contacts/delete-contact
@@ -206,14 +234,14 @@ class Contacts:
             email (str): The contact email
 
         Returns:
-            Contact: The removed contact object
+            RemoveContactResponse: The removed contact response object
         """
         contact = email if id is None else id
         if contact is None:
             raise ValueError("id or email must be provided")
         path = f"/audiences/{audience_id}/contacts/{contact}"
 
-        resp = request.Request[Contact](
+        resp = request.Request[Contacts.RemoveContactResponse](
             path=path, params={}, verb="delete"
         ).perform_with_content()
         return resp

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -7,21 +7,55 @@ from resend import request
 from ._contact import Contact
 
 
-class _ListResponse(TypedDict):
-    data: List[Contact]
-    """
-    A list of contact objects
-    """
-
-
 class Contacts:
 
-    class ListResponse(_ListResponse):
+    class ListResponse(TypedDict):
         """
         ListResponse type that wraps a list of contact objects
 
         Attributes:
             data (List[Contact]): A list of contact objects
+        """
+
+        data: List[Contact]
+        """
+        A list of contact objects
+        """
+
+    class CreateContactResponse(TypedDict):
+        """
+        CreateContactResponse is the type that wraps the response of the contact that was created
+
+        Attributes:
+            object (str): The ID of the created contact
+            id (str): The ID of the created contact
+        """
+
+        object: str
+        """
+        The object type: email
+        """
+        id: str
+        """
+        The ID of the scheduled email that was canceled.
+        """
+
+    class UpdateContactResponse(TypedDict):
+        """
+        UpdateContactResponse is the type that wraps the response of the contact that was updated
+
+        Attributes:
+            object (str): The ID of the updated contact
+            id (str): The ID of the updated contact
+        """
+
+        object: str
+        """
+        The object type: email
+        """
+        id: str
+        """
+        The ID of the updated contact.
         """
 
     class CreateParams(TypedDict):
@@ -73,7 +107,7 @@ class Contacts:
         """
 
     @classmethod
-    def create(cls, params: CreateParams) -> Contact:
+    def create(cls, params: CreateParams) -> CreateContactResponse:
         """
         Create a new contact.
         see more: https://resend.com/docs/api-reference/contacts/create-contact
@@ -82,16 +116,17 @@ class Contacts:
             params (CreateParams): The contact creation parameters
 
         Returns:
-            Contact: The new contact object
+            CreateContactResponse: The created contact response
         """
+
         path = f"/audiences/{params['audience_id']}/contacts"
-        resp = request.Request[Contact](
+        resp = request.Request[Contacts.CreateContactResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform_with_content()
         return resp
 
     @classmethod
-    def update(cls, params: UpdateParams) -> Contact:
+    def update(cls, params: UpdateParams) -> UpdateContactResponse:
         """
         Update an existing contact.
         see more: https://resend.com/docs/api-reference/contacts/update-contact
@@ -100,7 +135,7 @@ class Contacts:
             params (UpdateParams): The contact update parameters
 
         Returns:
-            Contact: The updated contact object
+            UpdateContactResponse: The updated contact response.
         """
         if params.get("id") is None and params.get("email") is None:
             raise ValueError("id or email must be provided")
@@ -108,7 +143,7 @@ class Contacts:
         val = params.get("id") if params.get("id") is not None else params.get("email")
 
         path = f"/audiences/{params['audience_id']}/contacts/{val}"
-        resp = request.Request[Contact](
+        resp = request.Request[Contacts.UpdateContactResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
@@ -126,7 +161,7 @@ class Contacts:
             ListResponse: A list of contact objects
         """
         path = f"/audiences/{audience_id}/contacts"
-        resp = request.Request[_ListResponse](
+        resp = request.Request[Contacts.ListResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp

--- a/resend/domains/_domains.py
+++ b/resend/domains/_domains.py
@@ -1,28 +1,65 @@
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Union, cast
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
 from resend import request
 from resend.domains._domain import Domain
+from resend.domains._record import Record
 
 TlsOptions = Literal["enforced", "opportunistic"]
 
 
-class _ListResponse(TypedDict):
-    data: List[Domain]
-    """
-    A list of domain objects
-    """
-
-
 class Domains:
 
-    class ListResponse(_ListResponse):
+    class ListResponse(TypedDict):
         """
         ListResponse type that wraps a list of domain objects
 
         Attributes:
             data (List[Domain]): A list of domain objects
+        """
+
+        data: List[Domain]
+        """
+        A list of domain objects
+        """
+
+    class CreateDomainResponse(TypedDict):
+        """
+        CreateDomainResponse is the type that wraps the response of the domain that was created
+
+        Attributes:
+            id (str): The ID of the created domain
+            name (str): The name of the created domain
+            created_at (str): When the domain was created
+            status (str): Status of the domain
+            region (str): The region where emails will be sent from
+            records (Union[List[Record], None]): The list of domain records
+        """
+
+        id: str
+        """
+        The ID of the created domain
+        """
+        name: str
+        """
+        The name of the created domain
+        """
+        created_at: str
+        """
+        When the domain was created
+        """
+        status: str
+        """
+        Status of the domain
+        """
+        region: str
+        """
+        The region where emails will be sent from
+        """
+        records: Union[List[Record], None]
+        """
+        The list of domain records
         """
 
     class UpdateParams(TypedDict):
@@ -68,7 +105,7 @@ class Domains:
         """
 
     @classmethod
-    def create(cls, params: CreateParams) -> Domain:
+    def create(cls, params: CreateParams) -> CreateDomainResponse:
         """
         Create a domain through the Resend Email API.
         see more: https://resend.com/docs/api-reference/domains/create-domain
@@ -77,10 +114,10 @@ class Domains:
             params (CreateParams): The domain creation parameters
 
         Returns:
-            Domain: The new domain object
+            CreateDomainResponse: The created domain response
         """
         path = "/domains"
-        resp = request.Request[Domain](
+        resp = request.Request[Domains.CreateDomainResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
         ).perform_with_content()
         return resp
@@ -131,7 +168,7 @@ class Domains:
             ListResponse: A list of domain objects
         """
         path = "/domains"
-        resp = request.Request[_ListResponse](
+        resp = request.Request[Domains.ListResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp

--- a/tests/api_keys_test.py
+++ b/tests/api_keys_test.py
@@ -17,7 +17,7 @@ class TestResendApiKeys(ResendBaseTest):
         params: resend.ApiKeys.CreateParams = {
             "name": "prod",
         }
-        key: resend.ApiKey = resend.ApiKeys.create(params)
+        key: resend.ApiKeys.CreateApiKeyResponse = resend.ApiKeys.create(params)
         assert key["id"] == "dacf4072-4119-4d88-932f-6202748ac7c8"
 
     def test_should_create_api_key_raise_exception_when_no_content(self) -> None:

--- a/tests/audiences_test.py
+++ b/tests/audiences_test.py
@@ -59,7 +59,10 @@ class TestResendAudiences(ResendBaseTest):
             }
         )
 
-        rmed = resend.Audiences.remove("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+        rmed: resend.Audiences.RemoveAudienceResponse = resend.Audiences.remove(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        )
+        assert rmed["object"] == "audience"
         assert rmed["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
         assert rmed["deleted"] is True
 

--- a/tests/contacts_test.py
+++ b/tests/contacts_test.py
@@ -93,8 +93,8 @@ class TestResendContacts(ResendBaseTest):
         )
         assert contact["id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
         assert contact["email"] == "steve.wozniak@gmail.com"
-        assert contact["first_name"] == "Steve"
-        assert contact["last_name"] == "Wozniak"
+        assert contact.get("first_name") == "Steve"
+        assert contact.get("last_name") == "Wozniak"
         assert contact["created_at"] == "2023-10-06T23:47:56.678Z"
         assert contact["unsubscribed"] is False
 
@@ -144,7 +144,7 @@ class TestResendContacts(ResendBaseTest):
         self.set_mock_json(
             {
                 "object": "contact",
-                "id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+                "contact": "520784e2-887d-4c25-b53c-4ad46ad38100",
                 "deleted": True,
             }
         )
@@ -153,7 +153,7 @@ class TestResendContacts(ResendBaseTest):
             audience_id="48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
             id="78261eea-8f8b-4381-83c6-79fa7120f1cf",
         )
-        assert rmed["id"] == "520784e2-887d-4c25-b53c-4ad46ad38100"
+        assert rmed["contact"] == "520784e2-887d-4c25-b53c-4ad46ad38100"
         assert rmed["deleted"] is True
 
     def test_should_remove_contacts_by_id_raise_exception_when_no_content(self) -> None:
@@ -168,16 +168,16 @@ class TestResendContacts(ResendBaseTest):
         self.set_mock_json(
             {
                 "object": "contact",
-                "id": "520784e2-887d-4c25-b53c-4ad46ad38100",
+                "contact": "520784e2-887d-4c25-b53c-4ad46ad38100",
                 "deleted": True,
             }
         )
 
-        rmed: resend.Contact = resend.Contacts.remove(
+        rmed: resend.Contacts.RemoveContactResponse = resend.Contacts.remove(
             audience_id="48c269ed-9873-4d60-bdd9-cd7e6fc0b9b8",
             email="someemail@email.com",
         )
-        assert rmed["id"] == "520784e2-887d-4c25-b53c-4ad46ad38100"
+        assert rmed["contact"] == "520784e2-887d-4c25-b53c-4ad46ad38100"
         assert rmed["deleted"] is True
 
     def test_should_remove_contacts_by_email_raise_exception_when_no_content(
@@ -222,8 +222,8 @@ class TestResendContacts(ResendBaseTest):
         )
         assert contacts["data"][0]["id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
         assert contacts["data"][0]["email"] == "steve.wozniak@gmail.com"
-        assert contacts["data"][0]["first_name"] == "Steve"
-        assert contacts["data"][0]["last_name"] == "Wozniak"
+        assert contacts["data"][0].get("first_name") == "Steve"
+        assert contacts["data"][0].get("last_name") == "Wozniak"
         assert contacts["data"][0]["created_at"] == "2023-10-06T23:47:56.678Z"
         assert contacts["data"][0]["unsubscribed"] is False
 

--- a/tests/contacts_test.py
+++ b/tests/contacts_test.py
@@ -18,7 +18,7 @@ class TestResendContacts(ResendBaseTest):
             "last_name": "Wozniak",
             "unsubscribed": True,
         }
-        contact: resend.Contact = resend.Contacts.create(params)
+        contact: resend.Contacts.CreateContactResponse = resend.Contacts.create(params)
         assert contact["id"] == "479e3145-dd38-476b-932c-529ceb705947"
 
     def test_should_create_contacts_raise_exception_when_no_content(self) -> None:

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -65,7 +65,9 @@ class TestResendDomains(ResendBaseTest):
             "region": "us-east-1",
             "custom_return_path": "send",
         }
-        domain = resend.Domains.create(params=create_params)
+        domain: resend.Domains.CreateDomainResponse = resend.Domains.create(
+            params=create_params
+        )
         assert domain["id"] == "4dd369bc-aa82-4ff3-97de-514ae3000ee0"
         assert domain["name"] == "example.com"
         assert domain["status"] == "not_started"


### PR DESCRIPTION
This PR does some cleaning on some typing definitions that were previously duplicated.
As well as changes the return types of the`create` methods of some modules:

- [x] Api Keys
- [x] Domains
- [x] Contacts  
- [x] Audiences 