### PR TITLE
chore: Bump to v2.14.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.13.1"
+__version__ = "2.14.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bump package version from 2.13.1 to 2.14.0 to prepare the release and ensure get_version() reports the new version.

<!-- End of auto-generated description by cubic. -->

