### PR TITLE
chore: Bump version to 2.15.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped package version to 2.15.0 for the next release. Updates __version__ in resend/version.py so packaging and release tooling recognize the new version.

<!-- End of auto-generated description by cubic. -->

