### PR TITLE
chore: Bump to v2.16.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.15.0"
+__version__ = "2.16.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped package version to 2.16.0 in resend/version.py to prepare the v2.16.0 release. No functional changes.

<!-- End of auto-generated description by cubic. -->

