### PR TITLE
feat: Impl templates API

### DIFF
--- a/examples/receiving_email.py
+++ b/examples/receiving_email.py
@@ -102,8 +102,8 @@ if paginated_emails["data"] and paginated_emails["has_more"]:
     print(f"Next page has more: {next_page['has_more']}")
 
 print("\n--- Listing All Attachments ---")
-all_attachments: EmailsReceiving.Attachments.ListResponse = resend.Emails.Receiving.Attachments.list(
-    email_id=email_id
+all_attachments: EmailsReceiving.Attachments.ListResponse = (
+    resend.Emails.Receiving.Attachments.list(email_id=email_id)
 )
 
 print(f"Total attachments: {len(all_attachments['data'])}")

--- a/examples/send_email_with_template.py
+++ b/examples/send_email_with_template.py
@@ -1,0 +1,72 @@
+import os
+from typing import List
+
+import resend
+
+if not os.environ["RESEND_API_KEY"]:
+    raise EnvironmentError("RESEND_API_KEY is missing")
+
+print("Step 1: Creating template variables...")
+variables: List[resend.Variable] = [
+    {
+        "key": "NAME",
+        "type": "string",
+        "fallback_value": "user",
+    },
+    {
+        "key": "AGE",
+        "type": "number",
+        "fallback_value": 25,
+    },
+]
+
+print("Step 2: Creating a new template...")
+create_params: resend.Templates.CreateParams = {
+    "name": "user-welcome-template",
+    "subject": "Welcome to our platform!",
+    "html": """
+    <html>
+        <body>
+            <h1>Welcome, {{{NAME}}}!</h1>
+            <p>Thank you for joining us. Your age is {{{AGE}}}.</p>
+        </body>
+    </html>
+    """,
+    "variables": variables,
+}
+
+template: resend.Templates.CreateResponse = resend.Templates.create(create_params)
+print(f"Created template: {template['id']}")
+
+print("Publishing the template...")
+published: resend.Templates.PublishResponse = resend.Templates.publish(template["id"])
+print(f"Published template: {published['id']}")
+
+# Create the template configuration with variables
+email_template: resend.EmailTemplate = {
+    "id": template["id"],
+    "variables": {
+        "NAME": "John Doe",
+        "AGE": 30,
+    },
+}
+
+# Send the email with the template
+send_params: resend.Emails.SendParams = {
+    "from": "onboarding@resend.dev",
+    "to": ["delivered@resend.dev"],
+    "template": email_template,
+}
+
+email: resend.Emails.SendResponse = resend.Emails.send(send_params)
+print(f"✓ Sent email using template: {email['id']}")
+
+sent_email: resend.Email = resend.Emails.get(email["id"])
+print(f"✓ Retrieved email: {sent_email['id']}")
+print(f"  From: {sent_email['from']}")
+print(f"  To: {sent_email['to']}")
+print(f"  Subject: {sent_email.get('subject', 'N/A')}")
+
+print("Cleaning up - removing the template...")
+removed: resend.Templates.RemoveResponse = resend.Templates.remove(template["id"])
+print(f"Deleted template: {removed['id']}, deleted={removed['deleted']}")

--- a/examples/templates.py
+++ b/examples/templates.py
@@ -32,6 +32,12 @@ print(f"Created template: {template['id']}")
 published: resend.Templates.PublishResponse = resend.Templates.publish(template["id"])
 print(f"Published template: {published['id']}")
 
+# Duplicate a template
+duplicated: resend.Templates.DuplicateResponse = resend.Templates.duplicate(
+    template["id"]
+)
+print(f"Duplicated template: {duplicated['id']}")
+
 # Get a template by ID
 retrieved_template: resend.Template = resend.Templates.get(template["id"])
 print(f"Retrieved template: {retrieved_template['name']}")
@@ -53,6 +59,11 @@ print(f"Total templates: {len(templates['data'])}")
 for t in templates["data"]:
     print(f"  - {t['name']} ({t['id']})")
 
-# Delete a template
+# Delete templates (cleanup)
 removed: resend.Templates.RemoveResponse = resend.Templates.remove(template["id"])
 print(f"Deleted template: {removed['id']}, deleted={removed['deleted']}")
+
+removed_dup: resend.Templates.RemoveResponse = resend.Templates.remove(duplicated["id"])
+print(
+    f"Deleted duplicated template: {removed_dup['id']}, deleted={removed_dup['deleted']}"
+)

--- a/examples/templates.py
+++ b/examples/templates.py
@@ -1,28 +1,32 @@
 """Example usage of the Templates API."""
 
 import os
+from typing import List
 
 import resend
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
+# Define template variables with explicit typing
+variables: List[resend.Variable] = [
+    {
+        "key": "NAME",
+        "type": "string",
+        "fallback_value": "user",
+    },
+    {
+        "key": "AGE",
+        "type": "number",
+        "fallback_value": 25,
+    },
+]
+
 # Create a new template with variables
 create_params: resend.Templates.CreateParams = {
     "name": "welcome-email",
     "html": "<strong>Hey, {{{NAME}}}, you are {{{AGE}}} years old.</strong>",
-    "variables": [
-        {
-            "key": "NAME",
-            "type": "string",
-            "fallback_value": "user",
-        },
-        {
-            "key": "AGE",
-            "type": "number",
-            "fallback_value": 25,
-        },
-    ],
+    "variables": variables,
 }
 
 template: resend.Templates.CreateResponse = resend.Templates.create(create_params)

--- a/examples/templates.py
+++ b/examples/templates.py
@@ -1,0 +1,58 @@
+"""Example usage of the Templates API."""
+
+import os
+
+import resend
+
+if not os.environ["RESEND_API_KEY"]:
+    raise EnvironmentError("RESEND_API_KEY is missing")
+
+# Create a new template with variables
+create_params: resend.Templates.CreateParams = {
+    "name": "welcome-email",
+    "html": "<strong>Hey, {{{NAME}}}, you are {{{AGE}}} years old.</strong>",
+    "variables": [
+        {
+            "key": "NAME",
+            "type": "string",
+            "fallback_value": "user",
+        },
+        {
+            "key": "AGE",
+            "type": "number",
+            "fallback_value": 25,
+        },
+    ],
+}
+
+template: resend.Templates.CreateResponse = resend.Templates.create(create_params)
+print(f"Created template: {template['id']}")
+
+# Publish the template to make it available for use
+published: resend.Templates.PublishResponse = resend.Templates.publish(template["id"])
+print(f"Published template: {published['id']}")
+
+# Get a template by ID
+retrieved_template: resend.Template = resend.Templates.get(template["id"])
+print(f"Retrieved template: {retrieved_template['name']}")
+
+# Update a template (update just the name, keep HTML/variables the same)
+update_params: resend.Templates.UpdateParams = {
+    "id": template["id"],
+    "name": "updated-welcome-email",
+}
+updated: resend.Templates.UpdateResponse = resend.Templates.update(update_params)
+print(f"Updated template: {updated['id']}")
+
+# List all templates with pagination
+list_params: resend.Templates.ListParams = {
+    "limit": 10,
+}
+templates: resend.Templates.ListResponse = resend.Templates.list(list_params)
+print(f"Total templates: {len(templates['data'])}")
+for t in templates["data"]:
+    print(f"  - {t['name']} ({t['id']})")
+
+# Delete a template
+removed: resend.Templates.RemoveResponse = resend.Templates.remove(template["id"])
+print(f"Deleted template: {removed['id']}, deleted={removed['deleted']}")

--- a/examples/with_attachments.py
+++ b/examples/with_attachments.py
@@ -1,6 +1,8 @@
 import os
 
 import resend
+# Type imports
+from resend import EmailAttachments
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
@@ -30,3 +32,38 @@ params: resend.Emails.SendParams = {
 email: resend.Emails.SendResponse = resend.Emails.send(params)
 print("Sent email with attachment")
 print(email)
+
+print("\n--- Retrieving Attachments ---")
+
+# List all attachments from the sent email
+attachments = resend.Emails.Attachments.list(email_id=email["id"])
+print(f"Email has {len(attachments['data'])} attachment(s)")
+print(f"Has more attachments: {attachments['has_more']}")
+
+# Get details of each attachment
+if attachments["data"]:
+    for i, attachment_item in enumerate(attachments["data"], 1):
+        print(f"\nAttachment {i}: {attachment_item['filename']}")
+        print(f"  - ID: {attachment_item['id']}")
+        print(f"  - Content Type: {attachment_item['content_type']}")
+        print(f"  - Size: {attachment_item['size']} bytes")
+        print(
+            f"  - Content Disposition: {attachment_item.get('content_disposition', 'N/A')}"
+        )
+
+        # Get detailed information about this attachment (including download URL)
+        attachment_details = resend.Emails.Attachments.get(
+            email_id=email["id"], attachment_id=attachment_item["id"]
+        )
+        print(f"  - Download URL: {attachment_details['download_url']}")
+        print(f"  - Expires at: {attachment_details['expires_at']}")
+
+# Example with pagination for attachments (useful when emails have many attachments)
+print("\n--- Paginating Attachments ---")
+attachment_params: EmailAttachments.ListParams = {
+    "limit": 10,
+}
+paginated_attachments = resend.Emails.Attachments.list(
+    email_id=email["id"], params=attachment_params
+)
+print(f"Retrieved {len(paginated_attachments['data'])} attachment(s) (limited to 10)")

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -24,7 +24,7 @@ from .emails._tag import Tag
 from .http_client import HTTPClient
 from .http_client_requests import RequestsClient
 from .request import Request
-from .templates._template import Template, Variable
+from .templates._template import Template, TemplateListItem, Variable
 from .templates._templates import Templates
 from .topics._topic import Topic
 from .topics._topics import Topics
@@ -70,6 +70,7 @@ __all__ = [
     "Tag",
     "Broadcast",
     "Template",
+    "TemplateListItem",
     "Variable",
     "Webhook",
     "WebhookEvent",

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -15,7 +15,7 @@ from .domains._domains import Domains
 from .emails._attachment import Attachment, RemoteAttachment
 from .emails._batch import Batch, BatchValidationError
 from .emails._email import Email
-from .emails._emails import Emails
+from .emails._emails import Emails, EmailTemplate
 from .emails._received_email import (ListReceivedEmail, ReceivedEmail,
                                      ReceivedEmailAttachment,
                                      ReceivedEmailAttachmentDetails)
@@ -66,6 +66,7 @@ __all__ = [
     "Email",
     "Attachment",
     "RemoteAttachment",
+    "EmailTemplate",
     "Tag",
     "Broadcast",
     "Template",

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -18,6 +18,8 @@ from .emails._tag import Tag
 from .http_client import HTTPClient
 from .http_client_requests import RequestsClient
 from .request import Request
+from .templates._template import Template, Variable
+from .templates._templates import Templates
 from .version import __version__, get_version
 
 # Config vars
@@ -41,6 +43,7 @@ __all__ = [
     "Audiences",
     "Contacts",
     "Broadcasts",
+    "Templates",
     # Types
     "Audience",
     "Contact",
@@ -51,6 +54,8 @@ __all__ = [
     "RemoteAttachment",
     "Tag",
     "Broadcast",
+    "Template",
+    "Variable",
     "BatchValidationError",
     # Default HTTP Client
     "RequestsClient",

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -15,8 +15,6 @@ from .emails._attachments import Attachments as EmailAttachments
 from .emails._batch import Batch, BatchValidationError
 from .emails._email import Email
 from .emails._emails import Emails, EmailTemplate
-from .emails._received_email import (ListReceivedEmail, ReceivedEmail)
-from .emails._emails import Emails
 from .emails._received_email import (EmailAttachment, EmailAttachmentDetails,
                                      ListReceivedEmail, ReceivedEmail)
 from .emails._receiving import Receiving as EmailsReceiving
@@ -39,9 +37,6 @@ api_url = os.environ.get("RESEND_API_URL", "https://api.resend.com")
 
 # HTTP Client
 default_http_client: HTTPClient = RequestsClient()
-
-# API resources
-from .emails._emails import Emails  # noqa
 
 __all__ = [
     "__version__",

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -10,6 +10,25 @@ from resend.emails._tag import Tag
 from resend.pagination_helper import PaginationHelper
 
 
+class EmailTemplate(TypedDict):
+    """
+    EmailTemplate is the class that wraps template configuration for email sending.
+
+    Attributes:
+        id (str): The template ID.
+        variables (NotRequired[Dict[str, Union[str, int, bool]]]): Optional variables to be used in the template.
+    """
+
+    id: str
+    """
+    The template ID.
+    """
+    variables: NotRequired[Dict[str, Union[str, int, bool]]]
+    """
+    Optional variables to be used in the template.
+    """
+
+
 class _UpdateParams(TypedDict):
     id: str
     """
@@ -50,7 +69,7 @@ class _CancelScheduledEmailResponse(TypedDict):
 _SendParamsFrom = TypedDict(
     "_SendParamsFrom",
     {
-        "from": str,
+        "from": NotRequired[str],
     },
 )
 
@@ -60,7 +79,7 @@ class _SendParamsDefault(_SendParamsFrom):
     """
     List of email addresses to send the email to.
     """
-    subject: str
+    subject: NotRequired[str]
     """
     The subject of the email.
     """
@@ -101,6 +120,10 @@ class _SendParamsDefault(_SendParamsFrom):
     Schedule email to be sent later.
     The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
     """
+    template: NotRequired[EmailTemplate]
+    """
+    Template configuration for sending emails using predefined templates.
+    """
 
 
 class Emails:
@@ -138,9 +161,9 @@ class Emails:
         """SendParams is the class that wraps the parameters for the send method.
 
         Attributes:
-            from (str): The email address to send the email from.
+            from (NotRequired[str]): The email address to send the email from.
             to (Union[str, List[str]]): List of email addresses to send the email to.
-            subject (str): The subject of the email.
+            subject (NotRequired[str]): The subject of the email.
             bcc (NotRequired[Union[List[str], str]]): Bcc
             cc (NotRequired[Union[List[str], str]]): Cc
             reply_to (NotRequired[Union[List[str], str]]): Reply to
@@ -149,6 +172,7 @@ class Emails:
             headers (NotRequired[Dict[str, str]]): Custom headers to be added to the email.
             attachments (NotRequired[List[Union[Attachment, RemoteAttachment]]]): List of attachments to be added to the email.
             tags (NotRequired[List[Tag]]): List of tags to be added to the email.
+            template (NotRequired[EmailTemplate]): Template configuration for sending emails using predefined templates.
         """
 
     class SendOptions(TypedDict):

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -16,14 +16,14 @@ class EmailTemplate(TypedDict):
 
     Attributes:
         id (str): The template ID.
-        variables (NotRequired[Dict[str, Union[str, int, bool]]]): Optional variables to be used in the template.
+        variables (NotRequired[Dict[str, Union[str, int]]]): Optional variables to be used in the template.
     """
 
     id: str
     """
     The template ID.
     """
-    variables: NotRequired[Dict[str, Union[str, int, bool]]]
+    variables: NotRequired[Dict[str, Union[str, int]]]
     """
     Optional variables to be used in the template.
     """

--- a/resend/templates/__init__.py
+++ b/resend/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Templates module."""

--- a/resend/templates/_template.py
+++ b/resend/templates/_template.py
@@ -103,23 +103,31 @@ class TemplateListItem(TypedDict):
 
     Attributes:
         id (str): The Template ID.
-        object (str): The object type (always "template").
         name (str): The name of the template.
-        html (str): The HTML version of the template.
+        status (Literal["draft", "published"]): The status of the template.
+        published_at (str | None): The timestamp when the template was published, or None if not published.
         created_at (str): The timestamp when the template was created.
+        updated_at (str): The timestamp when the template was last updated.
+        alias (str): The alias of the template.
     """
 
     id: str
     """The Template ID."""
 
-    object: str
-    """The object type (always "template")."""
-
     name: str
     """The name of the template."""
 
-    html: str
-    """The HTML version of the template."""
+    status: Literal["draft", "published"]
+    """The status of the template."""
+
+    published_at: Union[str, None]
+    """The timestamp when the template was published, or None if not published."""
 
     created_at: str
     """The timestamp when the template was created."""
+
+    updated_at: str
+    """The timestamp when the template was last updated."""
+
+    alias: str
+    """The alias of the template."""

--- a/resend/templates/_template.py
+++ b/resend/templates/_template.py
@@ -43,6 +43,7 @@ class Template(_FromParam):
         object (str): The object type (always "template").
         name (str): The name of the template.
         alias (str): The alias of the template.
+        status (str): The status of the template ("draft" or "published").
         from (str): Sender email address.
         subject (str): Email subject.
         reply_to (Union[List[str], str]): Reply-to email address(es).
@@ -65,6 +66,9 @@ class Template(_FromParam):
 
     alias: NotRequired[str]
     """The alias of the template."""
+
+    status: NotRequired[Literal["draft", "published"]]
+    """The status of the template."""
 
     subject: NotRequired[str]
     """Email subject."""

--- a/resend/templates/_template.py
+++ b/resend/templates/_template.py
@@ -10,16 +10,16 @@ class Variable(TypedDict):
 
     Attributes:
         key (str): The key of the variable. We recommend capitalizing the key (e.g. FIRST_NAME).
-        type (Literal["string", "number", "boolean", "object", "list"]): The type of the variable.
+        type (Literal["string", "number"]): The type of the variable.
         fallback_value (Any): The fallback value of the variable. Must match the type of the variable.
             If no fallback value is provided, you must provide a value for the variable when sending
-            an email using the template. If object type is provided, you must include a fallback.
+            an email using the template.
     """
 
     key: str
     """The key of the variable. We recommend capitalizing the key (e.g. FIRST_NAME)."""
 
-    type: Literal["string", "number", "boolean", "object", "list"]
+    type: Literal["string", "number"]
     """The type of the variable."""
 
     fallback_value: NotRequired[Any]
@@ -93,3 +93,33 @@ class Template(_FromParam):
 
     published_at: NotRequired[str]
     """The timestamp when the template was published."""
+
+
+class TemplateListItem(TypedDict):
+    """Template list item type returned in list responses.
+
+    This is a subset of the full Template object, containing only the fields
+    that are included in list responses.
+
+    Attributes:
+        id (str): The Template ID.
+        object (str): The object type (always "template").
+        name (str): The name of the template.
+        html (str): The HTML version of the template.
+        created_at (str): The timestamp when the template was created.
+    """
+
+    id: str
+    """The Template ID."""
+
+    object: str
+    """The object type (always "template")."""
+
+    name: str
+    """The name of the template."""
+
+    html: str
+    """The HTML version of the template."""
+
+    created_at: str
+    """The timestamp when the template was created."""

--- a/resend/templates/_template.py
+++ b/resend/templates/_template.py
@@ -1,0 +1,91 @@
+"""Template and Variable type definitions."""
+
+from typing import Any, List, Literal, Union
+
+from typing_extensions import NotRequired, TypedDict
+
+
+class Variable(TypedDict):
+    """Template variable type.
+
+    Attributes:
+        key (str): The key of the variable. We recommend capitalizing the key (e.g. FIRST_NAME).
+        type (Literal["string", "number", "boolean", "object", "list"]): The type of the variable.
+        fallback_value (Any): The fallback value of the variable. Must match the type of the variable.
+            If no fallback value is provided, you must provide a value for the variable when sending
+            an email using the template. If object type is provided, you must include a fallback.
+    """
+
+    key: str
+    """The key of the variable. We recommend capitalizing the key (e.g. FIRST_NAME)."""
+
+    type: Literal["string", "number", "boolean", "object", "list"]
+    """The type of the variable."""
+
+    fallback_value: NotRequired[Any]
+    """The fallback value of the variable. Must match the type of the variable."""
+
+
+# Use functional TypedDict syntax to support reserved keyword "from"
+_FromParam = TypedDict(
+    "_FromParam",
+    {
+        "from": NotRequired[str],
+    },
+)
+
+
+class Template(_FromParam):
+    """Template type that wraps the template object.
+
+    Attributes:
+        id (str): The Template ID.
+        object (str): The object type (always "template").
+        name (str): The name of the template.
+        alias (str): The alias of the template.
+        from (str): Sender email address.
+        subject (str): Email subject.
+        reply_to (Union[List[str], str]): Reply-to email address(es).
+        html (str): The HTML version of the template.
+        text (str): The plain text version of the template.
+        variables (List[Variable]): The array of variables used in the template.
+        created_at (str): The timestamp when the template was created.
+        updated_at (str): The timestamp when the template was last updated.
+        published_at (str): The timestamp when the template was published.
+    """
+
+    id: str
+    """The Template ID."""
+
+    object: str
+    """The object type (always "template")."""
+
+    name: str
+    """The name of the template."""
+
+    alias: NotRequired[str]
+    """The alias of the template."""
+
+    subject: NotRequired[str]
+    """Email subject."""
+
+    reply_to: NotRequired[Union[List[str], str]]
+    """Reply-to email address(es)."""
+
+    html: str
+    """The HTML version of the template."""
+
+    text: NotRequired[str]
+    """The plain text version of the template."""
+
+    variables: NotRequired[List[Variable]]
+    """The array of variables used in the template."""
+
+    created_at: NotRequired[str]
+    """The timestamp when the template was created."""
+
+    updated_at: NotRequired[str]
+    """The timestamp when the template was last updated."""
+
+    published_at: NotRequired[str]
+    """The timestamp when the template was published."""

--- a/resend/templates/_templates.py
+++ b/resend/templates/_templates.py
@@ -7,7 +7,7 @@ from typing_extensions import NotRequired, TypedDict
 from resend import request
 from resend.pagination_helper import PaginationHelper
 
-from ._template import Template, Variable
+from ._template import Template, TemplateListItem, Variable
 
 # Use functional TypedDict syntax to support reserved keyword "from"
 _CreateParamsFrom = TypedDict(
@@ -158,15 +158,15 @@ class Templates:
 
         Attributes:
             object (str): The object type (always "list").
-            data (List[Template]): Array of template objects.
+            data (List[TemplateListItem]): Array of template list items with a subset of template properties.
             has_more (bool): Whether there are more results available.
         """
 
         object: str
         """The object type (always "list")."""
 
-        data: List[Template]
-        """Array of template objects."""
+        data: List[TemplateListItem]
+        """Array of template list items with a subset of template properties."""
 
         has_more: bool
         """Whether there are more results available."""

--- a/resend/templates/_templates.py
+++ b/resend/templates/_templates.py
@@ -1,0 +1,310 @@
+"""Templates API operations."""
+
+from typing import Any, Dict, List, Optional, Union, cast
+
+from typing_extensions import NotRequired, TypedDict
+
+from resend import request
+from resend.pagination_helper import PaginationHelper
+
+from ._template import Template, Variable
+
+# Use functional TypedDict syntax to support reserved keyword "from"
+_CreateParamsFrom = TypedDict(
+    "_CreateParamsFrom",
+    {
+        "from": NotRequired[str],
+    },
+)
+
+
+class Templates:
+    """Templates API resource.
+
+    The Templates API allows you to create, manage, and publish email templates
+    with optional variables.
+    """
+
+    class CreateParams(_CreateParamsFrom):
+        """Parameters for creating a template.
+
+        Attributes:
+            name (str): The name of the template (required).
+            alias (str): The alias of the template.
+            from (str): Sender email address. To include a friendly name, use the format
+                "Your Name <sender@domain.com>". If provided, this value can be overridden
+                when sending an email using the template.
+            subject (str): Email subject. If provided, this value can be overridden when
+                sending an email using the template.
+            reply_to (Union[List[str], str]): Reply-to email address(es). For multiple
+                addresses, send as an array of strings. If provided, this value can be
+                overridden when sending an email using the template.
+            html (str): The HTML version of the template (required).
+            text (str): The plain text version of the message. If not provided, the HTML
+                will be used to generate a plain text version. You can opt out of this
+                behavior by setting value to an empty string.
+            variables (List[Variable]): The array of variables used in the template.
+                Each template may contain up to 20 variables.
+        """
+
+        name: str
+        """The name of the template."""
+
+        html: str
+        """The HTML version of the template."""
+
+        alias: NotRequired[str]
+        """The alias of the template."""
+
+        subject: NotRequired[str]
+        """Email subject."""
+
+        reply_to: NotRequired[Union[List[str], str]]
+        """Reply-to email address(es)."""
+
+        text: NotRequired[str]
+        """The plain text version of the message."""
+
+        variables: NotRequired[List[Variable]]
+        """The array of variables used in the template."""
+
+    class CreateResponse(TypedDict):
+        """Response from creating a template.
+
+        Attributes:
+            id (str): The Template ID.
+            object (str): The object type (always "template").
+        """
+
+        id: str
+        """The Template ID."""
+
+        object: str
+        """The object type (always "template")."""
+
+    class UpdateParams(_CreateParamsFrom):
+        """Parameters for updating a template.
+
+        Attributes:
+            id (str): The Template ID (required).
+            name (str): The name of the template.
+            alias (str): The alias of the template.
+            from (str): Sender email address.
+            subject (str): Email subject.
+            reply_to (Union[List[str], str]): Reply-to email address(es).
+            html (str): The HTML version of the template.
+            text (str): The plain text version of the message.
+            variables (List[Variable]): The array of variables used in the template.
+        """
+
+        id: str
+        """The Template ID."""
+
+        name: NotRequired[str]
+        """The name of the template."""
+
+        alias: NotRequired[str]
+        """The alias of the template."""
+
+        subject: NotRequired[str]
+        """Email subject."""
+
+        reply_to: NotRequired[Union[List[str], str]]
+        """Reply-to email address(es)."""
+
+        html: NotRequired[str]
+        """The HTML version of the template."""
+
+        text: NotRequired[str]
+        """The plain text version of the message."""
+
+        variables: NotRequired[List[Variable]]
+        """The array of variables used in the template."""
+
+    class UpdateResponse(TypedDict):
+        """Response from updating a template.
+
+        Attributes:
+            id (str): The Template ID.
+            object (str): The object type (always "template").
+        """
+
+        id: str
+        """The Template ID."""
+
+        object: str
+        """The object type (always "template")."""
+
+    class ListParams(TypedDict):
+        """Parameters for listing templates.
+
+        Attributes:
+            limit (int): The number of templates to return (max 100).
+            after (str): Return templates after this cursor.
+            before (str): Return templates before this cursor.
+        """
+
+        limit: NotRequired[int]
+        """The number of templates to return (max 100)."""
+
+        after: NotRequired[str]
+        """Return templates after this cursor."""
+
+        before: NotRequired[str]
+        """Return templates before this cursor."""
+
+    class ListResponse(TypedDict):
+        """Response from listing templates.
+
+        Attributes:
+            object (str): The object type (always "list").
+            data (List[Template]): Array of template objects.
+            has_more (bool): Whether there are more results available.
+        """
+
+        object: str
+        """The object type (always "list")."""
+
+        data: List[Template]
+        """Array of template objects."""
+
+        has_more: bool
+        """Whether there are more results available."""
+
+    class PublishResponse(TypedDict):
+        """Response from publishing a template.
+
+        Attributes:
+            id (str): The Template ID.
+            object (str): The object type (always "template").
+        """
+
+        id: str
+        """The Template ID."""
+
+        object: str
+        """The object type (always "template")."""
+
+    class RemoveResponse(TypedDict):
+        """Response from removing a template.
+
+        Attributes:
+            id (str): The Template ID.
+            object (str): The object type (always "template").
+            deleted (bool): Whether the template was deleted.
+        """
+
+        id: str
+        """The Template ID."""
+
+        object: str
+        """The object type (always "template")."""
+
+        deleted: bool
+        """Whether the template was deleted."""
+
+    @classmethod
+    def create(cls, params: CreateParams) -> CreateResponse:
+        """Create a new template.
+
+        Before you can use a template, you must publish it first. To publish a template,
+        use the Templates dashboard or publish() method.
+
+        Args:
+            params: The template creation parameters.
+
+        Returns:
+            CreateResponse: The created template response with ID and object type.
+        """
+        path = "/templates"
+        resp = request.Request[Templates.CreateResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def get(cls, template_id: str) -> Template:
+        """Retrieve a template by ID.
+
+        Args:
+            template_id: The Template ID.
+
+        Returns:
+            Template: The template object.
+        """
+        path = f"/templates/{template_id}"
+        resp = request.Request[Template](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def list(cls, params: Optional[ListParams] = None) -> ListResponse:
+        """List all templates with pagination support.
+
+        Args:
+            params: Optional pagination parameters (limit, after, before).
+
+        Returns:
+            ListResponse: The paginated list of templates.
+        """
+        base_path = "/templates"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[Templates.ListResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, params: UpdateParams) -> UpdateResponse:
+        """Update an existing template.
+
+        Args:
+            params: The template update parameters (must include id).
+
+        Returns:
+            UpdateResponse: The updated template response with ID and object type.
+        """
+        template_id = params["id"]
+        path = f"/templates/{template_id}"
+        # Remove 'id' from params before sending
+        update_params = {k: v for k, v in params.items() if k != "id"}
+        resp = request.Request[Templates.UpdateResponse](
+            path=path, params=cast(Dict[Any, Any], update_params), verb="patch"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def publish(cls, template_id: str) -> PublishResponse:
+        """Publish a template to make it available for use.
+
+        Before you can use a template to send emails, you must publish it first.
+
+        Args:
+            template_id: The Template ID.
+
+        Returns:
+            PublishResponse: The published template response with ID and object type.
+        """
+        path = f"/templates/{template_id}/publish"
+        resp = request.Request[Templates.PublishResponse](
+            path=path, params={}, verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def remove(cls, template_id: str) -> RemoveResponse:
+        """Delete a template.
+
+        Args:
+            template_id: The Template ID.
+
+        Returns:
+            RemoveResponse: The deletion response with ID, object type, and deleted status.
+        """
+        path = f"/templates/{template_id}"
+        resp = request.Request[Templates.RemoveResponse](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp

--- a/resend/templates/_templates.py
+++ b/resend/templates/_templates.py
@@ -185,6 +185,20 @@ class Templates:
         object: str
         """The object type (always "template")."""
 
+    class DuplicateResponse(TypedDict):
+        """Response from duplicating a template.
+
+        Attributes:
+            id (str): The Template ID of the duplicated template.
+            object (str): The object type (always "template").
+        """
+
+        id: str
+        """The Template ID of the duplicated template."""
+
+        object: str
+        """The object type (always "template")."""
+
     class RemoveResponse(TypedDict):
         """Response from removing a template.
 
@@ -289,6 +303,24 @@ class Templates:
         """
         path = f"/templates/{template_id}/publish"
         resp = request.Request[Templates.PublishResponse](
+            path=path, params={}, verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def duplicate(cls, template_id: str) -> DuplicateResponse:
+        """Duplicate a template.
+
+        Creates a copy of the specified template with all its properties and variables.
+
+        Args:
+            template_id: The Template ID to duplicate.
+
+        Returns:
+            DuplicateResponse: The duplicated template response with new ID and object type.
+        """
+        path = f"/templates/{template_id}/duplicate"
+        resp = request.Request[Templates.DuplicateResponse](
             path=path, params={}, verb="post"
         ).perform_with_content()
         return resp

--- a/tests/emails_test.py
+++ b/tests/emails_test.py
@@ -475,7 +475,6 @@ class TestResendEmail(ResendBaseTest):
             "variables": {
                 "name": "John Doe",
                 "age": 30,
-                "verified": True,
             },
         }
 

--- a/tests/emails_test.py
+++ b/tests/emails_test.py
@@ -443,3 +443,46 @@ class TestResendEmail(ResendBaseTest):
         self.set_mock_json(None)
         with self.assertRaises(NoContentError):
             _ = resend.Emails.Receiving.list()
+
+    def test_email_send_with_template(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            }
+        )
+
+        template: resend.EmailTemplate = {
+            "id": "template_12345",
+        }
+
+        params: resend.Emails.SendParams = {
+            "to": "to@email.com",
+            "from": "from@email.com",
+            "template": template,
+        }
+        email: resend.Emails.SendResponse = resend.Emails.send(params)
+        assert email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+
+    def test_email_send_with_template_and_variables(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            }
+        )
+
+        template: resend.EmailTemplate = {
+            "id": "template_12345",
+            "variables": {
+                "name": "John Doe",
+                "age": 30,
+                "verified": True,
+            },
+        }
+
+        params: resend.Emails.SendParams = {
+            "to": "to@email.com",
+            "from": "from@email.com",
+            "template": template,
+        }
+        email: resend.Emails.SendResponse = resend.Emails.send(params)
+        assert email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"

--- a/tests/templates_test.py
+++ b/tests/templates_test.py
@@ -266,7 +266,7 @@ class TestResendTemplates(ResendBaseTest):
 
         params: resend.Templates.CreateParams = {
             "name": "complex-template",
-            "html": "<div>{{{STRING}}} {{{NUMBER}}} {{{BOOLEAN}}} {{{OBJECT}}} {{{LIST}}}</div>",
+            "html": "<div>{{{STRING}}} {{{NUMBER}}} {{{AGE}}} {{{SCORE}}}</div>",
             "variables": [
                 {
                     "key": "STRING",
@@ -279,19 +279,14 @@ class TestResendTemplates(ResendBaseTest):
                     "fallback_value": 42,
                 },
                 {
-                    "key": "BOOLEAN",
-                    "type": "boolean",
-                    "fallback_value": True,
+                    "key": "AGE",
+                    "type": "number",
+                    "fallback_value": 25,
                 },
                 {
-                    "key": "OBJECT",
-                    "type": "object",
-                    "fallback_value": {"key": "value"},
-                },
-                {
-                    "key": "LIST",
-                    "type": "list",
-                    "fallback_value": ["item1", "item2"],
+                    "key": "SCORE",
+                    "type": "number",
+                    "fallback_value": 100,
                 },
             ],
         }

--- a/tests/templates_test.py
+++ b/tests/templates_test.py
@@ -134,6 +134,17 @@ class TestResendTemplates(ResendBaseTest):
         assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
         assert template["object"] == "template"
 
+    def test_templates_duplicate(self) -> None:
+        self.set_mock_json(
+            {"id": "e169aa45-1ecf-4183-9955-b1499d5701d3", "object": "template"}
+        )
+
+        duplicated: resend.Templates.DuplicateResponse = resend.Templates.duplicate(
+            "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        )
+        assert duplicated["id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
+        assert duplicated["object"] == "template"
+
     def test_templates_remove(self) -> None:
         self.set_mock_json(
             {

--- a/tests/templates_test.py
+++ b/tests/templates_test.py
@@ -169,17 +169,21 @@ class TestResendTemplates(ResendBaseTest):
                 "data": [
                     {
                         "id": "template-1",
-                        "object": "template",
                         "name": "welcome-email",
-                        "html": "<strong>Welcome!</strong>",
+                        "status": "published",
+                        "published_at": "2024-01-15T11:00:00.000Z",
                         "created_at": "2024-01-15T10:30:00.000Z",
+                        "updated_at": "2024-01-15T10:30:00.000Z",
+                        "alias": "welcome",
                     },
                     {
                         "id": "template-2",
-                        "object": "template",
                         "name": "goodbye-email",
-                        "html": "<strong>Goodbye!</strong>",
+                        "status": "draft",
+                        "published_at": None,
                         "created_at": "2024-01-16T10:30:00.000Z",
+                        "updated_at": "2024-01-16T10:30:00.000Z",
+                        "alias": "goodbye",
                     },
                 ],
             }
@@ -192,17 +196,21 @@ class TestResendTemplates(ResendBaseTest):
 
         template = templates["data"][0]
         assert template["id"] == "template-1"
-        assert template["object"] == "template"
         assert template["name"] == "welcome-email"
-        assert template["html"] == "<strong>Welcome!</strong>"
+        assert template["status"] == "published"
+        assert template["published_at"] == "2024-01-15T11:00:00.000Z"
         assert template["created_at"] == "2024-01-15T10:30:00.000Z"
+        assert template["updated_at"] == "2024-01-15T10:30:00.000Z"
+        assert template["alias"] == "welcome"
 
         template = templates["data"][1]
         assert template["id"] == "template-2"
-        assert template["object"] == "template"
         assert template["name"] == "goodbye-email"
-        assert template["html"] == "<strong>Goodbye!</strong>"
+        assert template["status"] == "draft"
+        assert template["published_at"] is None
         assert template["created_at"] == "2024-01-16T10:30:00.000Z"
+        assert template["updated_at"] == "2024-01-16T10:30:00.000Z"
+        assert template["alias"] == "goodbye"
 
     def test_templates_list_with_pagination_params(self) -> None:
         self.set_mock_json(
@@ -212,10 +220,12 @@ class TestResendTemplates(ResendBaseTest):
                 "data": [
                     {
                         "id": "template-1",
-                        "object": "template",
                         "name": "welcome-email",
-                        "html": "<strong>Welcome!</strong>",
+                        "status": "published",
+                        "published_at": "2024-01-15T11:00:00.000Z",
                         "created_at": "2024-01-15T10:30:00.000Z",
+                        "updated_at": "2024-01-15T10:30:00.000Z",
+                        "alias": "welcome",
                     }
                 ],
             }
@@ -239,10 +249,12 @@ class TestResendTemplates(ResendBaseTest):
                 "data": [
                     {
                         "id": "template-3",
-                        "object": "template",
                         "name": "password-reset",
-                        "html": "<strong>Reset your password</strong>",
+                        "status": "draft",
+                        "published_at": None,
                         "created_at": "2024-01-14T10:30:00.000Z",
+                        "updated_at": "2024-01-14T10:30:00.000Z",
+                        "alias": "password-reset",
                     }
                 ],
             }

--- a/tests/templates_test.py
+++ b/tests/templates_test.py
@@ -1,0 +1,289 @@
+import resend
+from tests.conftest import ResendBaseTest
+
+# flake8: noqa
+
+
+class TestResendTemplates(ResendBaseTest):
+    def test_templates_create(self) -> None:
+        self.set_mock_json(
+            {"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794", "object": "template"}
+        )
+
+        params: resend.Templates.CreateParams = {
+            "name": "welcome-email",
+            "html": "<strong>Hey, {{{NAME}}}, you are {{{AGE}}} years old.</strong>",
+            "variables": [
+                {
+                    "key": "NAME",
+                    "type": "string",
+                    "fallback_value": "user",
+                },
+                {
+                    "key": "AGE",
+                    "type": "number",
+                    "fallback_value": 25,
+                },
+            ],
+        }
+        template: resend.Templates.CreateResponse = resend.Templates.create(params)
+        assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert template["object"] == "template"
+
+    def test_templates_create_with_optional_fields(self) -> None:
+        self.set_mock_json(
+            {"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794", "object": "template"}
+        )
+
+        params: resend.Templates.CreateParams = {
+            "name": "welcome-email",
+            "alias": "welcome",
+            "from": "Acme <onboarding@example.com>",
+            "subject": "Welcome to Acme!",
+            "reply_to": "support@example.com",
+            "html": "<strong>Welcome, {{{NAME}}}!</strong>",
+            "text": "Welcome, {{{NAME}}}!",
+            "variables": [
+                {
+                    "key": "NAME",
+                    "type": "string",
+                    "fallback_value": "user",
+                }
+            ],
+        }
+        template: resend.Templates.CreateResponse = resend.Templates.create(params)
+        assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert template["object"] == "template"
+
+    def test_templates_get(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+                "object": "template",
+                "name": "welcome-email",
+                "alias": "welcome",
+                "from": "Acme <onboarding@example.com>",
+                "subject": "Welcome to Acme!",
+                "reply_to": "support@example.com",
+                "html": "<strong>Hey, {{{NAME}}}, you are {{{AGE}}} years old.</strong>",
+                "text": "Hey, {{{NAME}}}, you are {{{AGE}}} years old.",
+                "variables": [
+                    {
+                        "key": "NAME",
+                        "type": "string",
+                        "fallback_value": "user",
+                    },
+                    {
+                        "key": "AGE",
+                        "type": "number",
+                        "fallback_value": 25,
+                    },
+                ],
+                "created_at": "2024-01-15T10:30:00.000Z",
+                "updated_at": "2024-01-15T10:30:00.000Z",
+                "published_at": "2024-01-15T11:00:00.000Z",
+            }
+        )
+
+        template = resend.Templates.get("49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
+        assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert template["object"] == "template"
+        assert template["name"] == "welcome-email"
+        assert template["alias"] == "welcome"
+        assert template["from"] == "Acme <onboarding@example.com>"
+        assert template["subject"] == "Welcome to Acme!"
+        assert template["reply_to"] == "support@example.com"
+        assert (
+            template["html"]
+            == "<strong>Hey, {{{NAME}}}, you are {{{AGE}}} years old.</strong>"
+        )
+        assert template["text"] == "Hey, {{{NAME}}}, you are {{{AGE}}} years old."
+        assert len(template["variables"]) == 2
+        assert template["variables"][0]["key"] == "NAME"
+        assert template["variables"][0]["type"] == "string"
+        assert template["variables"][0]["fallback_value"] == "user"
+        assert template["variables"][1]["key"] == "AGE"
+        assert template["variables"][1]["type"] == "number"
+        assert template["variables"][1]["fallback_value"] == 25
+        assert template["created_at"] == "2024-01-15T10:30:00.000Z"
+        assert template["updated_at"] == "2024-01-15T10:30:00.000Z"
+        assert template["published_at"] == "2024-01-15T11:00:00.000Z"
+
+    def test_templates_update(self) -> None:
+        self.set_mock_json(
+            {"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794", "object": "template"}
+        )
+
+        params: resend.Templates.UpdateParams = {
+            "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            "name": "updated-welcome-email",
+            "html": "<strong>Welcome, {{{NAME}}}!</strong>",
+        }
+        template: resend.Templates.UpdateResponse = resend.Templates.update(params)
+        assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert template["object"] == "template"
+
+    def test_templates_publish(self) -> None:
+        self.set_mock_json(
+            {"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794", "object": "template"}
+        )
+
+        template: resend.Templates.PublishResponse = resend.Templates.publish(
+            "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        )
+        assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert template["object"] == "template"
+
+    def test_templates_remove(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+                "object": "template",
+                "deleted": True,
+            }
+        )
+
+        response: resend.Templates.RemoveResponse = resend.Templates.remove(
+            "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        )
+        assert response["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert response["object"] == "template"
+        assert response["deleted"] is True
+
+    def test_templates_list(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "template-1",
+                        "object": "template",
+                        "name": "welcome-email",
+                        "html": "<strong>Welcome!</strong>",
+                        "created_at": "2024-01-15T10:30:00.000Z",
+                    },
+                    {
+                        "id": "template-2",
+                        "object": "template",
+                        "name": "goodbye-email",
+                        "html": "<strong>Goodbye!</strong>",
+                        "created_at": "2024-01-16T10:30:00.000Z",
+                    },
+                ],
+            }
+        )
+
+        templates: resend.Templates.ListResponse = resend.Templates.list()
+        assert templates["object"] == "list"
+        assert templates["has_more"] is False
+        assert len(templates["data"]) == 2
+
+        template = templates["data"][0]
+        assert template["id"] == "template-1"
+        assert template["object"] == "template"
+        assert template["name"] == "welcome-email"
+        assert template["html"] == "<strong>Welcome!</strong>"
+        assert template["created_at"] == "2024-01-15T10:30:00.000Z"
+
+        template = templates["data"][1]
+        assert template["id"] == "template-2"
+        assert template["object"] == "template"
+        assert template["name"] == "goodbye-email"
+        assert template["html"] == "<strong>Goodbye!</strong>"
+        assert template["created_at"] == "2024-01-16T10:30:00.000Z"
+
+    def test_templates_list_with_pagination_params(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": True,
+                "data": [
+                    {
+                        "id": "template-1",
+                        "object": "template",
+                        "name": "welcome-email",
+                        "html": "<strong>Welcome!</strong>",
+                        "created_at": "2024-01-15T10:30:00.000Z",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Templates.ListParams = {
+            "limit": 10,
+            "after": "previous-template-id",
+        }
+        templates: resend.Templates.ListResponse = resend.Templates.list(params=params)
+        assert templates["object"] == "list"
+        assert templates["has_more"] is True
+        assert len(templates["data"]) == 1
+        assert templates["data"][0]["id"] == "template-1"
+
+    def test_templates_list_with_before_param(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "template-3",
+                        "object": "template",
+                        "name": "password-reset",
+                        "html": "<strong>Reset your password</strong>",
+                        "created_at": "2024-01-14T10:30:00.000Z",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Templates.ListParams = {
+            "limit": 5,
+            "before": "later-template-id",
+        }
+        templates: resend.Templates.ListResponse = resend.Templates.list(params=params)
+        assert templates["object"] == "list"
+        assert templates["has_more"] is False
+        assert len(templates["data"]) == 1
+        assert templates["data"][0]["id"] == "template-3"
+
+    def test_templates_variable_types(self) -> None:
+        """Test that various variable types are properly supported."""
+        self.set_mock_json(
+            {"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794", "object": "template"}
+        )
+
+        params: resend.Templates.CreateParams = {
+            "name": "complex-template",
+            "html": "<div>{{{STRING}}} {{{NUMBER}}} {{{BOOLEAN}}} {{{OBJECT}}} {{{LIST}}}</div>",
+            "variables": [
+                {
+                    "key": "STRING",
+                    "type": "string",
+                    "fallback_value": "default",
+                },
+                {
+                    "key": "NUMBER",
+                    "type": "number",
+                    "fallback_value": 42,
+                },
+                {
+                    "key": "BOOLEAN",
+                    "type": "boolean",
+                    "fallback_value": True,
+                },
+                {
+                    "key": "OBJECT",
+                    "type": "object",
+                    "fallback_value": {"key": "value"},
+                },
+                {
+                    "key": "LIST",
+                    "type": "list",
+                    "fallback_value": ["item1", "item2"],
+                },
+            ],
+        }
+        template: resend.Templates.CreateResponse = resend.Templates.create(params)
+        assert template["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert template["object"] == "template"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Implements the Templates API in the Python SDK to create, manage, and publish email templates with variables. Adds typed models and full CRUD operations, plus pagination and duplicate support, with examples and tests.

- **New Features**
  - Templates resource: create, get, list (limit, before/after), update, publish, duplicate, remove.
  - Template and Variable types with TypedDicts (including support for reserved "from"); variable types: string, number, boolean, object, list.
  - Exports Templates, Template, and Variable from the package for easy import.
  - Adds an example script and comprehensive tests.

<!-- End of auto-generated description by cubic. -->

