### PR TITLE
feat: Implement the beta Topics API

### DIFF
--- a/examples/topics.py
+++ b/examples/topics.py
@@ -1,0 +1,69 @@
+import os
+
+import resend
+
+if not os.environ["RESEND_API_KEY"]:
+    raise EnvironmentError("RESEND_API_KEY is missing")
+
+
+# Create a new topic
+create_params: resend.Topics.CreateParams = {
+    "name": "Weekly Newsletter",
+    "default_subscription": "opt_in",
+    "description": "Subscribe to our weekly newsletter for updates",
+}
+
+topic: resend.Topics.CreateTopicResponse = resend.Topics.create(create_params)
+print(f"Created topic with ID: {topic['id']}")
+print(topic)
+
+# Retrieve the topic
+retrieved: resend.Topic = resend.Topics.get(topic["id"])
+print("\nRetrieved topic:")
+print(retrieved)
+
+# Update the topic
+update_params: resend.Topics.UpdateParams = {
+    "name": "Monthly Newsletter",
+    "description": "Subscribe to our monthly newsletter for updates",
+}
+
+updated: resend.Topics.UpdateTopicResponse = resend.Topics.update(
+    id=topic["id"], params=update_params
+)
+print(f"\nUpdated topic with ID: {updated['id']}")
+print(updated)
+
+# Retrieve the updated topic to see changes
+updated_topic: resend.Topic = resend.Topics.get(topic["id"])
+print("\nRetrieved updated topic:")
+print(updated_topic)
+
+# List all topics
+list_response: resend.Topics.ListResponse = resend.Topics.list()
+print("\nList of topics:")
+print(f"Found {len(list_response['data'])} topics")
+print(f"Has more topics: {list_response['has_more']}")
+for t in list_response["data"]:
+    print(f"  - {t['name']} ({t['id']}): {t['default_subscription']}")
+
+# List topics with pagination parameters
+print("\n--- Using pagination parameters ---")
+if list_response["data"]:
+    paginated_params: resend.Topics.ListParams = {
+        "limit": 5,
+        "after": list_response["data"][0]["id"],
+    }
+    paginated_topics: resend.Topics.ListResponse = resend.Topics.list(
+        params=paginated_params
+    )
+    print(f"Retrieved {len(paginated_topics['data'])} topics with pagination")
+    print(f"Has more topics: {paginated_topics['has_more']}")
+else:
+    print("No topics available for pagination example")
+
+# Delete the topic
+removed: resend.Topics.RemoveTopicResponse = resend.Topics.remove(id=topic["id"])
+print(f"\nDeleted topic with ID: {removed['id']}")
+print(f"Deleted: {removed['deleted']}")
+print(removed)

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -18,6 +18,8 @@ from .emails._tag import Tag
 from .http_client import HTTPClient
 from .http_client_requests import RequestsClient
 from .request import Request
+from .topics._topic import Topic
+from .topics._topics import Topics
 from .version import __version__, get_version
 
 # Config vars
@@ -41,6 +43,7 @@ __all__ = [
     "Audiences",
     "Contacts",
     "Broadcasts",
+    "Topics",
     # Types
     "Audience",
     "Contact",
@@ -51,6 +54,7 @@ __all__ = [
     "RemoteAttachment",
     "Tag",
     "Broadcast",
+    "Topic",
     "BatchValidationError",
     # Default HTTP Client
     "RequestsClient",

--- a/resend/topics/_topic.py
+++ b/resend/topics/_topic.py
@@ -1,0 +1,24 @@
+from typing_extensions import TypedDict
+
+
+class Topic(TypedDict):
+    id: str
+    """
+    The unique identifier of the topic.
+    """
+    name: str
+    """
+    The topic name.
+    """
+    default_subscription: str
+    """
+    The default subscription preference for new contacts. Possible values: opt_in or opt_out.
+    """
+    description: str
+    """
+    The topic description.
+    """
+    created_at: str
+    """
+    The date and time the topic was created.
+    """

--- a/resend/topics/_topics.py
+++ b/resend/topics/_topics.py
@@ -1,0 +1,229 @@
+from typing import Any, Dict, List, Optional, cast
+
+from typing_extensions import NotRequired, TypedDict
+
+from resend import request
+from resend.pagination_helper import PaginationHelper
+
+from ._topic import Topic
+
+
+class Topics:
+
+    class CreateTopicResponse(TypedDict):
+        """
+        CreateTopicResponse is the type that wraps the response of the topic that was created
+
+        Attributes:
+            id (str): The ID of the created topic
+        """
+
+        id: str
+        """
+        The ID of the created topic
+        """
+
+    class CreateParams(TypedDict):
+        name: str
+        """
+        The topic name. Max length is 50 characters.
+        """
+        default_subscription: str
+        """
+        The default subscription preference for new contacts. Possible values: opt_in or opt_out.
+        This value cannot be changed later.
+        """
+        description: NotRequired[str]
+        """
+        The topic description. Max length is 200 characters.
+        """
+
+    class UpdateTopicResponse(TypedDict):
+        """
+        UpdateTopicResponse is the type that wraps the response of the topic that was updated
+
+        Attributes:
+            id (str): The ID of the updated topic
+        """
+
+        id: str
+        """
+        The ID of the updated topic
+        """
+
+    class UpdateParams(TypedDict, total=False):
+        name: str
+        """
+        The topic name. Max length is 50 characters.
+        """
+        description: str
+        """
+        The topic description. Max length is 200 characters.
+        """
+
+    class RemoveTopicResponse(TypedDict):
+        """
+        RemoveTopicResponse is the type that wraps the response of the topic that was removed
+
+        Attributes:
+            object (str): The object type, "topic"
+            id (str): The ID of the removed topic
+            deleted (bool): Whether the topic was deleted
+        """
+
+        object: str
+        """
+        The object type, "topic"
+        """
+        id: str
+        """
+        The ID of the removed topic
+        """
+        deleted: bool
+        """
+        Whether the topic was deleted
+        """
+
+    class ListParams(TypedDict):
+        limit: NotRequired[int]
+        """
+        Number of topics to retrieve. Maximum is 100, and minimum is 1.
+        """
+        after: NotRequired[str]
+        """
+        The ID after which we'll retrieve more topics (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the before parameter.
+        """
+        before: NotRequired[str]
+        """
+        The ID before which we'll retrieve more topics (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the after parameter.
+        """
+
+    class ListResponse(TypedDict):
+        """
+        ListResponse type that wraps a list of topic objects with pagination metadata
+
+        Attributes:
+            object (str): The object type, always "list"
+            data (List[Topic]): A list of topic objects
+            has_more (bool): Whether there are more results available
+        """
+
+        object: str
+        """
+        The object type, always "list"
+        """
+        data: List[Topic]
+        """
+        A list of topic objects
+        """
+        has_more: bool
+        """
+        Whether there are more results available for pagination
+        """
+
+    @classmethod
+    def create(cls, params: CreateParams) -> CreateTopicResponse:
+        """
+        Create a topic.
+        see more: https://resend.com/docs/api-reference/topics/create-topic
+
+        Args:
+            params (CreateParams): The topic creation parameters
+                - name: The topic name (max 50 characters)
+                - default_subscription: The default subscription preference ("opt_in" or "opt_out")
+                - description: Optional topic description (max 200 characters)
+
+        Returns:
+            CreateTopicResponse: The created topic response with the topic ID
+        """
+
+        path = "/topics"
+        resp = request.Request[Topics.CreateTopicResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def get(cls, id: str) -> Topic:
+        """
+        Retrieve a single topic by its ID.
+        see more: https://resend.com/docs/api-reference/topics/get-topic
+
+        Args:
+            id (str): The topic ID
+
+        Returns:
+            Topic: The topic object
+        """
+        path = f"/topics/{id}"
+        resp = request.Request[Topic](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, id: str, params: UpdateParams) -> UpdateTopicResponse:
+        """
+        Update an existing topic.
+        see more: https://resend.com/docs/api-reference/topics/update-topic
+
+        Args:
+            id (str): The topic ID
+            params (UpdateParams): The topic update parameters
+                - name: Optional topic name (max 50 characters)
+                - description: Optional topic description (max 200 characters)
+
+        Returns:
+            UpdateTopicResponse: The updated topic response with the topic ID
+        """
+        path = f"/topics/{id}"
+        resp = request.Request[Topics.UpdateTopicResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def remove(cls, id: str) -> RemoveTopicResponse:
+        """
+        Delete a single topic.
+        see more: https://resend.com/docs/api-reference/topics/delete-topic
+
+        Args:
+            id (str): The topic ID
+
+        Returns:
+            RemoveTopicResponse: The removed topic response
+        """
+        path = f"/topics/{id}"
+        resp = request.Request[Topics.RemoveTopicResponse](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def list(cls, params: Optional[ListParams] = None) -> ListResponse:
+        """
+        Retrieve a list of topics.
+        see more: https://resend.com/docs/api-reference/topics/list-topics
+
+        Args:
+            params (Optional[ListParams]): Optional pagination parameters
+                - limit: Number of topics to retrieve (max 100, min 1).
+                  If not provided, all topics will be returned without pagination.
+                - after: ID after which to retrieve more topics
+                - before: ID before which to retrieve more topics
+
+        Returns:
+            ListResponse: A list of topic objects
+        """
+        base_path = "/topics"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[Topics.ListResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp

--- a/tests/topics_test.py
+++ b/tests/topics_test.py
@@ -35,7 +35,7 @@ class TestResendTopics(ResendBaseTest):
         topic = resend.Topics.create(params)
         assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 
-    def test_should_create_topics_raise_exception_when_no_content(self) -> None:
+    def test_create_topics_raises_exception_when_no_content(self) -> None:
         self.set_mock_json(None)
         params: resend.Topics.CreateParams = {
             "name": "Weekly Newsletter",

--- a/tests/topics_test.py
+++ b/tests/topics_test.py
@@ -1,0 +1,237 @@
+import resend
+from resend.exceptions import NoContentError
+from tests.conftest import ResendBaseTest
+
+# flake8: noqa
+
+
+class TestResendTopics(ResendBaseTest):
+    def test_topics_create(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            }
+        )
+
+        params: resend.Topics.CreateParams = {
+            "name": "Weekly Newsletter",
+            "default_subscription": "opt_in",
+        }
+        topic = resend.Topics.create(params)
+        assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+    def test_topics_create_with_description(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            }
+        )
+
+        params: resend.Topics.CreateParams = {
+            "name": "Weekly Newsletter",
+            "default_subscription": "opt_in",
+            "description": "Subscribe to our weekly newsletter for updates",
+        }
+        topic = resend.Topics.create(params)
+        assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+    def test_should_create_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Topics.CreateParams = {
+            "name": "Weekly Newsletter",
+            "default_subscription": "opt_in",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Topics.create(params)
+
+    def test_topics_get(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+                "name": "Weekly Newsletter",
+                "description": "Weekly newsletter for our subscribers",
+                "default_subscription": "opt_in",
+                "created_at": "2023-04-08T00:11:13.110779+00:00",
+            }
+        )
+
+        topic = resend.Topics.get(id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+        assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+        assert topic["name"] == "Weekly Newsletter"
+        assert topic["description"] == "Weekly newsletter for our subscribers"
+        assert topic["default_subscription"] == "opt_in"
+        assert topic["created_at"] == "2023-04-08T00:11:13.110779+00:00"
+
+    def test_should_get_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Topics.get(id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+
+    def test_topics_update(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            }
+        )
+
+        params: resend.Topics.UpdateParams = {
+            "name": "Monthly Newsletter",
+            "description": "Monthly newsletter for our subscribers",
+        }
+        topic = resend.Topics.update(
+            id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e", params=params
+        )
+        assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+    def test_topics_update_name_only(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            }
+        )
+
+        params: resend.Topics.UpdateParams = {
+            "name": "Monthly Newsletter",
+        }
+        topic = resend.Topics.update(
+            id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e", params=params
+        )
+        assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+    def test_topics_update_description_only(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            }
+        )
+
+        params: resend.Topics.UpdateParams = {
+            "description": "Updated description",
+        }
+        topic = resend.Topics.update(
+            id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e", params=params
+        )
+        assert topic["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+    def test_should_update_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Topics.UpdateParams = {
+            "name": "Monthly Newsletter",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Topics.update(
+                id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e", params=params
+            )
+
+    def test_topics_remove(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "topic",
+                "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+                "deleted": True,
+            }
+        )
+
+        removed: resend.Topics.RemoveTopicResponse = resend.Topics.remove(
+            "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+        )
+        assert removed["object"] == "topic"
+        assert removed["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+        assert removed["deleted"] is True
+
+    def test_should_remove_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Topics.remove(id="b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+
+    def test_topics_list(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+                        "name": "Weekly Newsletter",
+                        "description": "Weekly newsletter for our subscribers",
+                        "default_subscription": "opt_in",
+                        "created_at": "2023-04-08T00:11:13.110779+00:00",
+                    }
+                ],
+            }
+        )
+
+        topics: resend.Topics.ListResponse = resend.Topics.list()
+        assert topics["object"] == "list"
+        assert topics["has_more"] is False
+        assert topics["data"][0]["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+        assert topics["data"][0]["name"] == "Weekly Newsletter"
+        assert topics["data"][0]["description"] == "Weekly newsletter for our subscribers"
+        assert topics["data"][0]["default_subscription"] == "opt_in"
+
+    def test_should_list_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Topics.list()
+
+    def test_topics_list_with_pagination_params(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": True,
+                "data": [
+                    {
+                        "id": "topic-1",
+                        "name": "First Topic",
+                        "description": "First topic description",
+                        "default_subscription": "opt_in",
+                        "created_at": "2023-04-08T00:11:13.110779+00:00",
+                    },
+                    {
+                        "id": "topic-2",
+                        "name": "Second Topic",
+                        "description": "Second topic description",
+                        "default_subscription": "opt_out",
+                        "created_at": "2023-04-09T00:11:13.110779+00:00",
+                    },
+                ],
+            }
+        )
+
+        params: resend.Topics.ListParams = {
+            "limit": 10,
+            "after": "previous-topic-id",
+        }
+        topics: resend.Topics.ListResponse = resend.Topics.list(params=params)
+        assert topics["object"] == "list"
+        assert topics["has_more"] is True
+        assert len(topics["data"]) == 2
+        assert topics["data"][0]["id"] == "topic-1"
+        assert topics["data"][1]["id"] == "topic-2"
+
+    def test_topics_list_with_before_param(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "topic-3",
+                        "name": "Third Topic",
+                        "description": "Third topic description",
+                        "default_subscription": "opt_in",
+                        "created_at": "2023-04-07T00:11:13.110779+00:00",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Topics.ListParams = {
+            "limit": 5,
+            "before": "later-topic-id",
+        }
+        topics: resend.Topics.ListResponse = resend.Topics.list(params=params)
+        assert topics["object"] == "list"
+        assert topics["has_more"] is False
+        assert len(topics["data"]) == 1
+        assert topics["data"][0]["id"] == "topic-3"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Implements the beta Topics API to manage topics with full CRUD and pagination. Exposes the Topics client and Topic types, with example usage and tests.

- **New Features**
  - Topics client: create, get, update, list (limit/after/before), and remove.
  - Typed models: Topic, Create/Update/List params, and response types.
  - Public exports: Topics and Topic in resend.__init__.
  - Example script demonstrating the workflow.
  - Tests covering all methods and NoContentError cases.

<!-- End of auto-generated description by cubic. -->

