### PR TITLE
feat: initial webhooks API support

### DIFF
--- a/examples/receiving_email.py
+++ b/examples/receiving_email.py
@@ -1,7 +1,6 @@
 import os
 
 import resend
-
 # Type imports
 from resend import AttachmentsReceiving, EmailsReceiving
 

--- a/examples/webhook_receiver.py
+++ b/examples/webhook_receiver.py
@@ -1,0 +1,96 @@
+"""
+Webhook Receiver Example
+
+Demonstrates how to receive and verify webhooks from Resend.
+This example creates an HTTP server that listens for webhook POST requests
+and verifies them using HMAC-SHA256 signature validation.
+
+Requirements:
+    pip install flask
+
+Usage:
+    1. Set your webhook secret (get it when creating a webhook)
+    2. Run: python examples/webhook_receiver.py
+    3. Send a POST request with Resend webhook headers to test verification
+
+Note:
+    For local testing, you can use tools like ngrok to expose your local server:
+    ngrok http 5000
+    Then use the ngrok URL when creating your webhook in Resend.
+"""
+
+import json
+import os
+from typing import Any, Dict, Tuple, Union
+
+from flask import Flask, request
+
+import resend
+
+app = Flask(__name__)
+
+# Get webhook secret from environment or use a placeholder
+WEBHOOK_SECRET = os.getenv(
+    "RESEND_WEBHOOK_SECRET", "whsec_zC+p1uXQxsAgZfH0SxB3lrl1DcSb4iPX"
+)
+
+
+@app.route("/webhook", methods=["POST"])
+def webhook_handler() -> Tuple[Dict[str, Union[str, bool]], int]:
+    """
+    Handle incoming webhook requests from Resend.
+    Verifies the webhook signature and processes the event.
+    """
+    # Read the raw body (must be raw for signature verification)
+    body = request.get_data(as_text=True)
+
+    # Extract Svix headers
+    headers: resend.WebhookHeaders = {
+        "id": request.headers.get("svix-id", ""),
+        "timestamp": request.headers.get("svix-timestamp", ""),
+        "signature": request.headers.get("svix-signature", ""),
+    }
+
+    # Verify the webhook
+    try:
+        resend.Webhooks.verify(
+            {
+                "payload": body,
+                "headers": headers,
+                "webhook_secret": WEBHOOK_SECRET,
+            }
+        )
+    except ValueError as e:
+        print(f"Webhook verification failed: {e}")
+        return {"error": "Webhook verification failed"}, 400
+
+    # Parse the verified payload
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON: {e}")
+        return {"error": "Invalid JSON payload"}, 400
+
+    # Process the webhook event
+    event_type = payload.get("type")
+    print(f"✓ Webhook verified successfully!")
+    print(f"Event Type: {event_type}")
+    print(f"Payload: {json.dumps(payload, indent=2)}")
+
+    print(f"Event: {payload.get('data', {}).get('email_id')}")
+
+    return {"success": True}, 200
+
+
+@app.route("/health", methods=["GET"])
+def health_check() -> Tuple[Dict[str, str], int]:
+    """Health check endpoint"""
+    return {"status": "healthy"}, 200
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", 5000))
+    print(f"🚀 Webhook receiver listening on http://localhost:{port}/webhook")
+    print("Send a POST request with Resend webhook headers to test verification")
+    print(f"Using webhook secret: {WEBHOOK_SECRET[:15]}...")
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/examples/webhook_receiver.py
+++ b/examples/webhook_receiver.py
@@ -19,9 +19,11 @@ Note:
     Then use the ngrok URL when creating your webhook in Resend.
 """
 
+# mypy: ignore-errors
+
 import json
 import os
-from typing import Any, Dict, Tuple, Union
+from typing import Dict, Tuple, Union
 
 from flask import Flask, request
 
@@ -73,19 +75,13 @@ def webhook_handler() -> Tuple[Dict[str, Union[str, bool]], int]:
 
     # Process the webhook event
     event_type = payload.get("type")
-    print(f"✓ Webhook verified successfully!")
+    print("✓ Webhook verified successfully!")
     print(f"Event Type: {event_type}")
     print(f"Payload: {json.dumps(payload, indent=2)}")
 
     print(f"Event: {payload.get('data', {}).get('email_id')}")
 
     return {"success": True}, 200
-
-
-@app.route("/health", methods=["GET"])
-def health_check() -> Tuple[Dict[str, str], int]:
-    """Health check endpoint"""
-    return {"status": "healthy"}, 200
 
 
 if __name__ == "__main__":

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -2,12 +2,11 @@ import os
 from typing import List
 
 import resend
-from resend.webhooks import WebhookEvent
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
-events: List[WebhookEvent] = ["email.sent", "email.delivered", "email.bounced"]
+events: List[resend.WebhookEvent] = ["email.sent", "email.delivered", "email.bounced"]
 
 create_params: resend.Webhooks.CreateParams = {
     "endpoint": "https://webhook.example.com/handler",

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -2,14 +2,16 @@ import os
 from typing import List
 
 import resend
+from resend.webhooks import WebhookEvent
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
+events: List[WebhookEvent] = ["email.sent", "email.delivered", "email.bounced"]
 
 create_params: resend.Webhooks.CreateParams = {
     "endpoint": "https://webhook.example.com/handler",
-    "events": ["email.sent", "email.delivered", "email.bounced"],
+    "events": events,
 }
 webhook: resend.Webhooks.CreateWebhookResponse = resend.Webhooks.create(
     params=create_params

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -1,0 +1,66 @@
+import os
+from typing import List
+
+import resend
+
+if not os.environ["RESEND_API_KEY"]:
+    raise EnvironmentError("RESEND_API_KEY is missing")
+
+
+create_params: resend.Webhooks.CreateParams = {
+    "endpoint": "https://webhook.example.com/handler",
+    "events": ["email.sent", "email.delivered", "email.bounced"],
+}
+webhook: resend.Webhooks.CreateWebhookResponse = resend.Webhooks.create(
+    params=create_params
+)
+print(f"Created webhook: {webhook['id']}")
+print(f"Signing secret: {webhook['signing_secret']}")
+print(webhook)
+
+retrieved: resend.Webhook = resend.Webhooks.get(webhook_id=webhook["id"])
+print(f"Retrieved webhook: {retrieved['id']}")
+print(f"Endpoint: {retrieved['endpoint']}")
+print(f"Events: {retrieved['events']}")
+print(f"Status: {retrieved['status']}")
+
+update_params: resend.Webhooks.UpdateParams = {
+    "webhook_id": webhook["id"],
+    "endpoint": "https://new-webhook.example.com/handler",
+    "events": ["email.sent", "email.delivered"],
+    "status": "enabled",
+}
+
+updated_webhook: resend.Webhooks.UpdateWebhookResponse = resend.Webhooks.update(
+    update_params
+)
+print(f"Updated webhook: {updated_webhook['id']}")
+
+webhooks: resend.Webhooks.ListResponse = resend.Webhooks.list()
+print(f"Found {len(webhooks['data'])} webhooks")
+print(f"Has more webhooks: {webhooks['has_more']}")
+if not webhooks["data"]:
+    print("No webhooks found")
+for hook in webhooks["data"]:
+    print(hook)
+
+print("\n--- Using pagination parameters ---")
+if webhooks["data"]:
+    paginated_params: resend.Webhooks.ListParams = {
+        "limit": 5,
+        "after": webhooks["data"][0]["id"],
+    }
+    paginated_webhooks: resend.Webhooks.ListResponse = resend.Webhooks.list(
+        params=paginated_params
+    )
+    print(f"Retrieved {len(paginated_webhooks['data'])} webhooks with pagination")
+    print(f"Has more webhooks: {paginated_webhooks['has_more']}")
+else:
+    print("No webhooks available for pagination example")
+
+rm_webhook: resend.Webhooks.DeleteWebhookResponse = resend.Webhooks.remove(
+    webhook_id=webhook["id"]
+)
+print(f"Deleted webhook: {rm_webhook['id']}")
+print(f"Deleted: {rm_webhook['deleted']}")
+print(rm_webhook)

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -19,6 +19,8 @@ from .http_client import HTTPClient
 from .http_client_requests import RequestsClient
 from .request import Request
 from .version import __version__, get_version
+from .webhooks._webhook import Webhook
+from .webhooks._webhooks import Webhooks
 
 # Config vars
 api_key = os.environ.get("RESEND_API_KEY")
@@ -41,6 +43,7 @@ __all__ = [
     "Audiences",
     "Contacts",
     "Broadcasts",
+    "Webhooks",
     # Types
     "Audience",
     "Contact",
@@ -51,6 +54,7 @@ __all__ = [
     "RemoteAttachment",
     "Tag",
     "Broadcast",
+    "Webhook",
     "BatchValidationError",
     # Default HTTP Client
     "RequestsClient",

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -27,7 +27,8 @@ from .request import Request
 from .topics._topic import Topic
 from .topics._topics import Topics
 from .version import __version__, get_version
-from .webhooks._webhook import Webhook
+from .webhooks._webhook import (VerifyWebhookOptions, Webhook, WebhookEvent,
+                                WebhookHeaders, WebhookStatus)
 from .webhooks._webhooks import Webhooks
 
 # Config vars
@@ -65,6 +66,10 @@ __all__ = [
     "Tag",
     "Broadcast",
     "Webhook",
+    "WebhookEvent",
+    "WebhookHeaders",
+    "WebhookStatus",
+    "VerifyWebhookOptions",
     "Topic",
     "BatchValidationError",
     "ReceivedEmail",

--- a/resend/webhooks/__init__.py
+++ b/resend/webhooks/__init__.py
@@ -1,4 +1,4 @@
-from resend.webhooks._webhook import Webhook
+from resend.webhooks._webhook import Webhook, WebhookEvent, WebhookStatus
 from resend.webhooks._webhooks import Webhooks
 
-__all__ = ["Webhook", "Webhooks"]
+__all__ = ["Webhook", "WebhookEvent", "WebhookStatus", "Webhooks"]

--- a/resend/webhooks/__init__.py
+++ b/resend/webhooks/__init__.py
@@ -1,4 +1,0 @@
-from resend.webhooks._webhook import Webhook, WebhookEvent, WebhookStatus
-from resend.webhooks._webhooks import Webhooks
-
-__all__ = ["Webhook", "WebhookEvent", "WebhookStatus", "Webhooks"]

--- a/resend/webhooks/__init__.py
+++ b/resend/webhooks/__init__.py
@@ -1,0 +1,4 @@
+from resend.webhooks._webhook import Webhook
+from resend.webhooks._webhooks import Webhooks
+
+__all__ = ["Webhook", "Webhooks"]

--- a/resend/webhooks/_webhook.py
+++ b/resend/webhooks/_webhook.py
@@ -4,6 +4,27 @@ from typing_extensions import Literal, TypedDict
 
 WebhookStatus = Literal["enabled", "disabled"]
 
+WebhookEvent = Literal[
+    # Email events
+    "email.sent",
+    "email.delivered",
+    "email.delivery_delayed",
+    "email.complained",
+    "email.bounced",
+    "email.opened",
+    "email.clicked",
+    "email.received",
+    "email.failed",
+    # Contact events
+    "contact.created",
+    "contact.updated",
+    "contact.deleted",
+    # Domain events
+    "domain.created",
+    "domain.updated",
+    "domain.deleted",
+]
+
 
 class Webhook(TypedDict):
     """
@@ -39,7 +60,7 @@ class Webhook(TypedDict):
     """
     The URL where webhook events will be sent
     """
-    events: List[str]
+    events: List[WebhookEvent]
     """
     Array of event types to subscribe to
     """

--- a/resend/webhooks/_webhook.py
+++ b/resend/webhooks/_webhook.py
@@ -1,0 +1,47 @@
+from typing import List, Union
+
+from typing_extensions import TypedDict
+
+
+class Webhook(TypedDict):
+    """
+    Webhook represents a webhook configuration object
+
+    Attributes:
+        id (str): The webhook ID
+        object (str): The object type, always "webhook"
+        created_at (str): When the webhook was created
+        status (str): The webhook status, either "enabled" or "disabled"
+        endpoint (str): The URL where webhook events will be sent
+        events (List[str]): Array of event types to subscribe to
+        signing_secret (Union[str, None]): The signing secret for webhook verification
+    """
+
+    id: str
+    """
+    The webhook ID
+    """
+    object: str
+    """
+    The object type, always "webhook"
+    """
+    created_at: str
+    """
+    When the webhook was created (ISO 8601 format)
+    """
+    status: str
+    """
+    The webhook status, either "enabled" or "disabled"
+    """
+    endpoint: str
+    """
+    The URL where webhook events will be sent
+    """
+    events: List[str]
+    """
+    Array of event types to subscribe to
+    """
+    signing_secret: Union[str, None]
+    """
+    The signing secret for webhook verification
+    """

--- a/resend/webhooks/_webhook.py
+++ b/resend/webhooks/_webhook.py
@@ -2,6 +2,8 @@ from typing import List, Union
 
 from typing_extensions import TypedDict
 
+from resend.webhooks._webhooks import WebhookStatus
+
 
 class Webhook(TypedDict):
     """
@@ -29,7 +31,7 @@ class Webhook(TypedDict):
     """
     When the webhook was created (ISO 8601 format)
     """
-    status: str
+    status: WebhookStatus
     """
     The webhook status, either "enabled" or "disabled"
     """

--- a/resend/webhooks/_webhook.py
+++ b/resend/webhooks/_webhook.py
@@ -1,8 +1,8 @@
 from typing import List, Union
 
-from typing_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
-from resend.webhooks._webhooks import WebhookStatus
+WebhookStatus = Literal["enabled", "disabled"]
 
 
 class Webhook(TypedDict):

--- a/resend/webhooks/_webhook.py
+++ b/resend/webhooks/_webhook.py
@@ -26,6 +26,54 @@ WebhookEvent = Literal[
 ]
 
 
+class WebhookHeaders(TypedDict):
+    """
+    WebhookHeaders contains the Svix headers required for webhook verification
+
+    Attributes:
+        id (str): The svix-id header value
+        timestamp (str): The svix-timestamp header value
+        signature (str): The svix-signature header value
+    """
+
+    id: str
+    """
+    The svix-id header value
+    """
+    timestamp: str
+    """
+    The svix-timestamp header value
+    """
+    signature: str
+    """
+    The svix-signature header value
+    """
+
+
+class VerifyWebhookOptions(TypedDict):
+    """
+    VerifyWebhookOptions contains the parameters needed to verify a webhook
+
+    Attributes:
+        payload (str): The raw request body as a string
+        headers (WebhookHeaders): The Svix headers from the request
+        webhook_secret (str): The webhook signing secret (starts with whsec_)
+    """
+
+    payload: str
+    """
+    The raw request body as a string
+    """
+    headers: WebhookHeaders
+    """
+    The Svix headers from the request
+    """
+    webhook_secret: str
+    """
+    The webhook signing secret (starts with whsec_)
+    """
+
+
 class Webhook(TypedDict):
     """
     Webhook represents a webhook configuration object

--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -1,0 +1,253 @@
+from typing import Any, Dict, List, Optional, Union, cast
+
+from typing_extensions import Literal, NotRequired, TypedDict
+
+from resend import request
+from resend.webhooks._webhook import Webhook
+from resend.pagination_helper import PaginationHelper
+
+WebhookStatus = Literal["enabled", "disabled"]
+
+
+class Webhooks:
+
+    class ListParams(TypedDict):
+        limit: NotRequired[int]
+        """
+        Number of webhooks to retrieve. Maximum is 100, and minimum is 1.
+        """
+        after: NotRequired[str]
+        """
+        The ID after which we'll retrieve more webhooks (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the before parameter.
+        """
+        before: NotRequired[str]
+        """
+        The ID before which we'll retrieve more webhooks (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the after parameter.
+        """
+
+    class ListResponse(TypedDict):
+        """
+        ListResponse type that wraps a list of webhook objects with pagination metadata
+
+        Attributes:
+            object (str): The object type, always "list"
+            data (List[Webhook]): A list of webhook objects
+            has_more (bool): Whether there are more results available
+        """
+
+        object: str
+        """
+        The object type, always "list"
+        """
+        data: List[Webhook]
+        """
+        A list of webhook objects
+        """
+        has_more: bool
+        """
+        Whether there are more results available for pagination
+        """
+
+    class CreateWebhookResponse(TypedDict):
+        """
+        CreateWebhookResponse is the type that wraps the response of the webhook that was created
+
+        Attributes:
+            object (str): The object type, always "webhook"
+            id (str): The ID of the created webhook
+            signing_secret (str): The signing secret for webhook verification
+        """
+
+        object: str
+        """
+        The object type, always "webhook"
+        """
+        id: str
+        """
+        The ID of the created webhook
+        """
+        signing_secret: str
+        """
+        The signing secret for webhook verification
+        """
+
+    class CreateParams(TypedDict):
+        endpoint: str
+        """
+        The URL where webhook events will be sent.
+        """
+        events: List[str]
+        """
+        Array of event types to subscribe to.
+        See https://resend.com/docs/dashboard/webhooks/event-types for available options.
+        """
+
+    class UpdateParams(TypedDict):
+        webhook_id: str
+        """
+        The webhook ID.
+        """
+        endpoint: NotRequired[str]
+        """
+        The URL where webhook events will be sent.
+        """
+        events: NotRequired[List[str]]
+        """
+        Array of event types to subscribe to.
+        """
+        status: NotRequired[WebhookStatus]
+        """
+        The webhook status. Can be either "enabled" or "disabled".
+        """
+
+    class UpdateWebhookResponse(TypedDict):
+        """
+        UpdateWebhookResponse is the type that wraps the response of the webhook that was updated
+
+        Attributes:
+            object (str): The object type, always "webhook"
+            id (str): The ID of the updated webhook
+        """
+
+        object: str
+        """
+        The object type, always "webhook"
+        """
+        id: str
+        """
+        The ID of the updated webhook
+        """
+
+    class DeleteWebhookResponse(TypedDict):
+        """
+        DeleteWebhookResponse is the type that wraps the response of the webhook that was deleted
+
+        Attributes:
+            object (str): The object type, always "webhook"
+            id (str): The ID of the deleted webhook
+            deleted (bool): Whether the webhook was successfully deleted
+        """
+
+        object: str
+        """
+        The object type, always "webhook"
+        """
+        id: str
+        """
+        The ID of the deleted webhook
+        """
+        deleted: bool
+        """
+        Whether the webhook was successfully deleted
+        """
+
+    @classmethod
+    def create(cls, params: CreateParams) -> CreateWebhookResponse:
+        """
+        Create a webhook to receive real-time notifications about email events.
+        see more: https://resend.com/docs/api-reference/webhooks/create-webhook
+
+        Args:
+            params (CreateParams): The webhook creation parameters
+                - endpoint: The URL where webhook events will be sent
+                - events: Array of event types to subscribe to
+
+        Returns:
+            CreateWebhookResponse: The created webhook response with id and signing_secret
+        """
+        path = "/webhooks"
+        resp = request.Request[Webhooks.CreateWebhookResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def get(cls, webhook_id: str) -> Webhook:
+        """
+        Retrieve a single webhook for the authenticated user.
+        see more: https://resend.com/docs/api-reference/webhooks/get-webhook
+
+        Args:
+            webhook_id (str): The webhook ID
+
+        Returns:
+            Webhook: The webhook object
+        """
+        path = f"/webhooks/{webhook_id}"
+        resp = request.Request[Webhook](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, params: UpdateParams) -> UpdateWebhookResponse:
+        """
+        Update an existing webhook configuration.
+        see more: https://resend.com/docs/api-reference/webhooks/update-webhook
+
+        Args:
+            params (UpdateParams): The webhook update parameters
+                - webhook_id: The webhook ID
+                - endpoint: (Optional) The URL where webhook events will be sent
+                - events: (Optional) Array of event types to subscribe to
+                - status: (Optional) The webhook status ("enabled" or "disabled")
+
+        Returns:
+            UpdateWebhookResponse: The updated webhook response with id
+        """
+        webhook_id = params["webhook_id"]
+        path = f"/webhooks/{webhook_id}"
+
+        # Remove webhook_id from params before sending to API
+        update_payload = {k: v for k, v in params.items() if k != "webhook_id"}
+
+        resp = request.Request[Webhooks.UpdateWebhookResponse](
+            path=path, params=cast(Dict[Any, Any], update_payload), verb="patch"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def list(cls, params: Optional[ListParams] = None) -> ListResponse:
+        """
+        Retrieve a list of webhooks for the authenticated user.
+        see more: https://resend.com/docs/api-reference/webhooks/list-webhooks
+
+        Args:
+            params (Optional[ListParams]): Optional pagination parameters
+                - limit: Number of webhooks to retrieve (max 100, min 1).
+                  If not provided, all webhooks will be returned without pagination.
+                - after: ID after which to retrieve more webhooks
+                - before: ID before which to retrieve more webhooks
+
+        Returns:
+            ListResponse: A list of webhook objects
+        """
+        base_path = "/webhooks"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[Webhooks.ListResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def remove(cls, webhook_id: str) -> DeleteWebhookResponse:
+        """
+        Remove an existing webhook.
+        see more: https://resend.com/docs/api-reference/webhooks/delete-webhook
+
+        Args:
+            webhook_id (str): The webhook ID
+
+        Returns:
+            DeleteWebhookResponse: The deleted webhook response
+        """
+        path = f"/webhooks/{webhook_id}"
+        resp = request.Request[Webhooks.DeleteWebhookResponse](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp

--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -4,7 +4,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.pagination_helper import PaginationHelper
-from resend.webhooks._webhook import Webhook, WebhookStatus
+from resend.webhooks._webhook import Webhook, WebhookEvent, WebhookStatus
 
 
 class Webhooks:
@@ -78,7 +78,7 @@ class Webhooks:
         """
         The URL where webhook events will be sent.
         """
-        events: List[str]
+        events: List[WebhookEvent]
         """
         Array of event types to subscribe to.
         See https://resend.com/docs/dashboard/webhooks/event-types for available options.
@@ -93,7 +93,7 @@ class Webhooks:
         """
         The URL where webhook events will be sent.
         """
-        events: NotRequired[List[str]]
+        events: NotRequired[List[WebhookEvent]]
         """
         Array of event types to subscribe to.
         """
@@ -200,11 +200,8 @@ class Webhooks:
         webhook_id = params["webhook_id"]
         path = f"/webhooks/{webhook_id}"
 
-        # Remove webhook_id from params before sending to API
-        update_payload = {k: v for k, v in params.items() if k != "webhook_id"}
-
         resp = request.Request[Webhooks.UpdateWebhookResponse](
-            path=path, params=cast(Dict[Any, Any], update_payload), verb="patch"
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
 

--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, cast
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
 from resend import request
-from resend.webhooks._webhook import Webhook
 from resend.pagination_helper import PaginationHelper
+from resend.webhooks._webhook import Webhook
 
 WebhookStatus = Literal["enabled", "disabled"]
 

--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -1,12 +1,10 @@
 from typing import Any, Dict, List, Optional, cast
 
-from typing_extensions import Literal, NotRequired, TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.pagination_helper import PaginationHelper
-from resend.webhooks._webhook import Webhook
-
-WebhookStatus = Literal["enabled", "disabled"]
+from resend.webhooks._webhook import Webhook, WebhookStatus
 
 
 class Webhooks:

--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -8,12 +8,8 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.pagination_helper import PaginationHelper
-from resend.webhooks._webhook import (
-    VerifyWebhookOptions,
-    Webhook,
-    WebhookEvent,
-    WebhookStatus,
-)
+from resend.webhooks._webhook import (VerifyWebhookOptions, Webhook,
+                                      WebhookEvent, WebhookStatus)
 
 # Default tolerance for timestamp validation (5 minutes)
 DEFAULT_WEBHOOK_TOLERANCE_SECONDS = 300

--- a/tests/topics_test.py
+++ b/tests/topics_test.py
@@ -166,7 +166,9 @@ class TestResendTopics(ResendBaseTest):
         assert topics["has_more"] is False
         assert topics["data"][0]["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
         assert topics["data"][0]["name"] == "Weekly Newsletter"
-        assert topics["data"][0]["description"] == "Weekly newsletter for our subscribers"
+        assert (
+            topics["data"][0]["description"] == "Weekly newsletter for our subscribers"
+        )
         assert topics["data"][0]["default_subscription"] == "opt_in"
 
     def test_should_list_topics_raise_exception_when_no_content(self) -> None:

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -1,0 +1,314 @@
+import base64
+import hmac
+import time
+from hashlib import sha256
+from typing import Any, Dict
+
+import pytest
+
+import resend
+from tests.conftest import ResendBaseTest
+
+
+class TestWebhooks(ResendBaseTest):
+    def test_webhooks_create(self) -> None:
+        create_webhook_response = {
+            "object": "webhook",
+            "id": "wh_123",
+            "signing_secret": "whsec_test123",
+        }
+        self.set_mock_json(create_webhook_response)
+
+        params: resend.Webhooks.CreateParams = {
+            "endpoint": "https://example.com/webhook",
+            "events": ["email.sent", "email.delivered"],
+        }
+
+        webhook = resend.Webhooks.create(params)
+        assert webhook["id"] == "wh_123"
+        assert webhook["signing_secret"] == "whsec_test123"
+
+    def test_webhooks_get(self) -> None:
+        webhook_response = {
+            "id": "wh_123",
+            "object": "webhook",
+            "created_at": "2024-01-01T00:00:00Z",
+            "status": "enabled",
+            "endpoint": "https://example.com/webhook",
+            "events": ["email.sent"],
+            "signing_secret": None,
+        }
+        self.set_mock_json(webhook_response)
+
+        webhook = resend.Webhooks.get("wh_123")
+        assert webhook["id"] == "wh_123"
+        assert webhook["endpoint"] == "https://example.com/webhook"
+        assert webhook["status"] == "enabled"
+
+    def test_webhooks_update(self) -> None:
+        update_response = {"object": "webhook", "id": "wh_123"}
+        self.set_mock_json(update_response)
+
+        params: resend.Webhooks.UpdateParams = {
+            "webhook_id": "wh_123",
+            "endpoint": "https://new-endpoint.com/webhook",
+            "status": "disabled",
+        }
+
+        webhook = resend.Webhooks.update(params)
+        assert webhook["id"] == "wh_123"
+
+    def test_webhooks_list(self) -> None:
+        list_response = {
+            "object": "list",
+            "data": [
+                {
+                    "id": "wh_123",
+                    "object": "webhook",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "status": "enabled",
+                    "endpoint": "https://example.com/webhook",
+                    "events": ["email.sent"],
+                    "signing_secret": None,
+                }
+            ],
+            "has_more": False,
+        }
+        self.set_mock_json(list_response)
+
+        webhooks = resend.Webhooks.list()
+        assert webhooks["object"] == "list"
+        assert len(webhooks["data"]) == 1
+        assert webhooks["data"][0]["id"] == "wh_123"
+
+    def test_webhooks_remove(self) -> None:
+        delete_response = {"object": "webhook", "id": "wh_123", "deleted": True}
+        self.set_mock_json(delete_response)
+
+        result = resend.Webhooks.remove("wh_123")
+        assert result["id"] == "wh_123"
+        assert result["deleted"] is True
+
+
+class TestWebhookVerification:
+    """Test webhook signature verification"""
+
+    def _generate_test_signature(
+        self, secret: str, msg_id: str, timestamp: str, payload: str
+    ) -> str:
+        """Generate a valid signature for testing"""
+        # Remove whsec_ prefix and decode
+        secret_bytes = base64.b64decode(secret.replace("whsec_", ""))
+
+        # Construct signed content
+        signed_content = f"{msg_id}.{timestamp}.{payload}"
+
+        # Generate signature
+        h = hmac.new(secret_bytes, signed_content.encode("utf-8"), sha256)
+        signature = base64.b64encode(h.digest()).decode("utf-8")
+
+        return f"v1,{signature}"
+
+    def test_verify_valid_webhook(self) -> None:
+        """Test successful webhook verification"""
+        # Use a base64-encoded secret
+        secret = "whsec_" + base64.b64encode(b"test_secret_key").decode("utf-8")
+        msg_id = "msg_123"
+        timestamp = str(int(time.time()))
+        payload = '{"type":"email.sent","data":{"email_id":"123"}}'
+
+        signature = self._generate_test_signature(secret, msg_id, timestamp, payload)
+
+        headers: resend.WebhookHeaders = {
+            "id": msg_id,
+            "timestamp": timestamp,
+            "signature": signature,
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": payload,
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        # Should not raise an exception
+        resend.Webhooks.verify(options)
+
+    def test_verify_invalid_signature(self) -> None:
+        """Test webhook verification with invalid signature"""
+        secret = "whsec_" + base64.b64encode(b"test_secret_key").decode("utf-8")
+        msg_id = "msg_123"
+        timestamp = str(int(time.time()))
+        payload = '{"type":"email.sent","data":{"email_id":"123"}}'
+
+        headers: resend.WebhookHeaders = {
+            "id": msg_id,
+            "timestamp": timestamp,
+            "signature": "v1,invalid_signature",
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": payload,
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        with pytest.raises(ValueError, match="no matching signature found"):
+            resend.Webhooks.verify(options)
+
+    def test_verify_expired_timestamp(self) -> None:
+        """Test webhook verification with expired timestamp"""
+        secret = "whsec_" + base64.b64encode(b"test_secret_key").decode("utf-8")
+        msg_id = "msg_123"
+        # Timestamp from 10 minutes ago (beyond the 5-minute tolerance)
+        timestamp = str(int(time.time()) - 600)
+        payload = '{"type":"email.sent","data":{"email_id":"123"}}'
+
+        signature = self._generate_test_signature(secret, msg_id, timestamp, payload)
+
+        headers: resend.WebhookHeaders = {
+            "id": msg_id,
+            "timestamp": timestamp,
+            "signature": signature,
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": payload,
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        with pytest.raises(ValueError, match="timestamp outside tolerance window"):
+            resend.Webhooks.verify(options)
+
+    def test_verify_missing_payload(self) -> None:
+        """Test webhook verification with missing payload"""
+        secret = "whsec_test123"
+
+        headers: resend.WebhookHeaders = {
+            "id": "msg_123",
+            "timestamp": str(int(time.time())),
+            "signature": "v1,sig",
+        }
+
+        options: Dict[str, Any] = {
+            "payload": "",
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        with pytest.raises(ValueError, match="payload cannot be empty"):
+            resend.Webhooks.verify(options)  # type: ignore
+
+    def test_verify_missing_webhook_secret(self) -> None:
+        """Test webhook verification with missing webhook secret"""
+        headers: resend.WebhookHeaders = {
+            "id": "msg_123",
+            "timestamp": str(int(time.time())),
+            "signature": "v1,sig",
+        }
+
+        options: Dict[str, Any] = {
+            "payload": "test",
+            "headers": headers,
+            "webhook_secret": "",
+        }
+
+        with pytest.raises(ValueError, match="webhook_secret cannot be empty"):
+            resend.Webhooks.verify(options)  # type: ignore
+
+    def test_verify_missing_headers(self) -> None:
+        """Test webhook verification with missing headers"""
+        secret = "whsec_test123"
+
+        # Test missing svix-id
+        headers: resend.WebhookHeaders = {
+            "id": "",
+            "timestamp": str(int(time.time())),
+            "signature": "v1,sig",
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": "test",
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        with pytest.raises(ValueError, match="svix-id header is required"):
+            resend.Webhooks.verify(options)
+
+    def test_verify_invalid_timestamp_format(self) -> None:
+        """Test webhook verification with invalid timestamp format"""
+        secret = "whsec_" + base64.b64encode(b"test_secret_key").decode("utf-8")
+
+        headers: resend.WebhookHeaders = {
+            "id": "msg_123",
+            "timestamp": "not_a_number",
+            "signature": "v1,sig",
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": "test",
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        with pytest.raises(ValueError, match="invalid timestamp format"):
+            resend.Webhooks.verify(options)
+
+    def test_verify_multiple_signatures(self) -> None:
+        """Test webhook verification with multiple signatures (one valid)"""
+        secret = "whsec_" + base64.b64encode(b"test_secret_key").decode("utf-8")
+        msg_id = "msg_123"
+        timestamp = str(int(time.time()))
+        payload = '{"type":"email.sent","data":{"email_id":"123"}}'
+
+        valid_signature = self._generate_test_signature(
+            secret, msg_id, timestamp, payload
+        )
+
+        # Create signature header with multiple signatures (Svix format)
+        headers: resend.WebhookHeaders = {
+            "id": msg_id,
+            "timestamp": timestamp,
+            "signature": f"v1,invalid_sig1 {valid_signature} v1,invalid_sig2",
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": payload,
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        # Should not raise an exception (finds the valid signature)
+        resend.Webhooks.verify(options)
+
+    def test_verify_tampered_payload(self) -> None:
+        """Test webhook verification with tampered payload"""
+        secret = "whsec_" + base64.b64encode(b"test_secret_key").decode("utf-8")
+        msg_id = "msg_123"
+        timestamp = str(int(time.time()))
+        original_payload = '{"type":"email.sent","data":{"email_id":"123"}}'
+
+        # Generate signature with original payload
+        signature = self._generate_test_signature(
+            secret, msg_id, timestamp, original_payload
+        )
+
+        # But try to verify with tampered payload
+        tampered_payload = '{"type":"email.sent","data":{"email_id":"456"}}'
+
+        headers: resend.WebhookHeaders = {
+            "id": msg_id,
+            "timestamp": timestamp,
+            "signature": signature,
+        }
+
+        options: resend.VerifyWebhookOptions = {
+            "payload": tampered_payload,
+            "headers": headers,
+            "webhook_secret": secret,
+        }
+
+        with pytest.raises(ValueError, match="no matching signature found"):
+            resend.Webhooks.verify(options)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds initial Webhooks API support to the Python SDK to create, retrieve, update, list (with pagination), and delete webhook configurations. This exposes typed models and a simple client for managing webhooks end-to-end.

- **New Features**
  - Webhooks client: create, get, update, list, remove.
  - Typed models: Webhook, response types, status literals.
  - Pagination support for list via PaginationHelper.
  - Exports Webhooks and Webhook from resend.__init__ and submodule.
  - Example script (examples/webhooks.py) showing common operations.

<!-- End of auto-generated description by cubic. -->

