### PR TITLE
feat: make new attachments API conform to updated spec

### DIFF
--- a/examples/receiving_email.py
+++ b/examples/receiving_email.py
@@ -2,7 +2,7 @@ import os
 
 import resend
 # Type imports
-from resend import AttachmentsReceiving, EmailsReceiving
+from resend import EmailsReceiving
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
@@ -102,7 +102,7 @@ if paginated_emails["data"] and paginated_emails["has_more"]:
     print(f"Next page has more: {next_page['has_more']}")
 
 print("\n--- Listing All Attachments ---")
-all_attachments: AttachmentsReceiving.ListResponse = resend.Attachments.Receiving.list(
+all_attachments: EmailsReceiving.Attachments.ListResponse = resend.Emails.Receiving.Attachments.list(
     email_id=email_id
 )
 
@@ -124,7 +124,7 @@ if received_email["attachments"] and len(received_email["attachments"]) > 0:
     print(f"\n--- Retrieving Attachment Details: {first_attachment['filename']} ---")
 
     attachment_details: resend.ReceivedEmailAttachmentDetails = (
-        resend.Attachments.Receiving.get(
+        resend.Emails.Receiving.Attachments.get(
             email_id=email_id,
             attachment_id=attachment_id,
         )

--- a/examples/receiving_email.py
+++ b/examples/receiving_email.py
@@ -123,7 +123,7 @@ if received_email["attachments"] and len(received_email["attachments"]) > 0:
 
     print(f"\n--- Retrieving Attachment Details: {first_attachment['filename']} ---")
 
-    attachment_details: resend.ReceivedEmailAttachmentDetails = (
+    attachment_details: resend.EmailAttachmentDetails = (
         resend.Emails.Receiving.Attachments.get(
             email_id=email_id,
             attachment_id=attachment_id,

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -15,9 +15,8 @@ from .emails._attachments import Attachments as EmailAttachments
 from .emails._batch import Batch, BatchValidationError
 from .emails._email import Email
 from .emails._emails import Emails
-from .emails._received_email import (ListReceivedEmail, ReceivedEmail,
-                                     ReceivedEmailAttachment,
-                                     ReceivedEmailAttachmentDetails)
+from .emails._received_email import (EmailAttachment, EmailAttachmentDetails,
+                                     ListReceivedEmail, ReceivedEmail)
 from .emails._receiving import Receiving as EmailsReceiving
 from .emails._tag import Tag
 from .http_client import HTTPClient
@@ -71,8 +70,8 @@ __all__ = [
     "Topic",
     "BatchValidationError",
     "ReceivedEmail",
-    "ReceivedEmailAttachment",
-    "ReceivedEmailAttachmentDetails",
+    "EmailAttachment",
+    "EmailAttachmentDetails",
     "ListReceivedEmail",
     # Receiving types (for type hints)
     "EmailsReceiving",

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -2,8 +2,6 @@ import os
 
 from .api_keys._api_key import ApiKey
 from .api_keys._api_keys import ApiKeys
-from .attachments._attachments import Attachments
-from .attachments._receiving import Receiving as AttachmentsReceiving
 from .audiences._audience import Audience
 from .audiences._audiences import Audiences
 from .broadcasts._broadcast import Broadcast
@@ -13,6 +11,7 @@ from .contacts._contacts import Contacts
 from .domains._domain import Domain
 from .domains._domains import Domains
 from .emails._attachment import Attachment, RemoteAttachment
+from .emails._attachments import Attachments as EmailAttachments
 from .emails._batch import Batch, BatchValidationError
 from .emails._email import Email
 from .emails._emails import Emails
@@ -53,7 +52,6 @@ __all__ = [
     "Contacts",
     "Broadcasts",
     "Webhooks",
-    "Attachments",
     "Topics",
     # Types
     "Audience",
@@ -78,7 +76,7 @@ __all__ = [
     "ListReceivedEmail",
     # Receiving types (for type hints)
     "EmailsReceiving",
-    "AttachmentsReceiving",
+    "EmailAttachments",
     # Default HTTP Client
     "RequestsClient",
 ]

--- a/resend/attachments/_attachments.py
+++ b/resend/attachments/_attachments.py
@@ -1,9 +1,0 @@
-from resend.attachments._receiving import Receiving
-
-
-class Attachments:
-    """
-    Attachments class that provides methods for managing email attachments.
-    """
-
-    Receiving = Receiving

--- a/resend/emails/_attachments.py
+++ b/resend/emails/_attachments.py
@@ -67,7 +67,7 @@ class Attachments:
     def get(cls, email_id: str, attachment_id: str) -> EmailAttachmentDetails:
         """
         Retrieve a single attachment from a sent email.
-        see more: https://resend.com/docs/api-reference/attachments/retrieve-attachment
+        see more: https://resend.com/docs/api-reference/attachments/retrieve-sent-email-attachment
 
         Args:
             email_id (str): The ID of the sent email
@@ -88,7 +88,7 @@ class Attachments:
     def list(cls, email_id: str, params: Optional[ListParams] = None) -> ListResponse:
         """
         Retrieve a list of attachments from a sent email.
-        see more: https://resend.com/docs/api-reference/attachments/list-attachments
+        see more: https://resend.com/docs/api-reference/attachments/list-sent-email-attachments
 
         Args:
             email_id (str): The ID of the sent email

--- a/resend/emails/_attachments.py
+++ b/resend/emails/_attachments.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, List, Optional, cast
 from typing_extensions import NotRequired, TypedDict
 
 from resend import request
-from resend.emails._received_email import (ReceivedEmailAttachment,
-                                           ReceivedEmailAttachmentDetails)
+from resend.emails._received_email import (EmailAttachment,
+                                           EmailAttachmentDetails)
 from resend.pagination_helper import PaginationHelper
 
 
@@ -28,7 +28,7 @@ class _ListResponse(TypedDict):
     """
     The object type: "list"
     """
-    data: List[ReceivedEmailAttachment]
+    data: List[EmailAttachment]
     """
     The list of attachment objects.
     """
@@ -59,12 +59,12 @@ class Attachments:
 
         Attributes:
             object (str): The object type: "list"
-            data (List[ReceivedEmailAttachment]): The list of attachment objects.
+            data (List[EmailAttachment]): The list of attachment objects.
             has_more (bool): Whether there are more attachments available for pagination.
         """
 
     @classmethod
-    def get(cls, email_id: str, attachment_id: str) -> ReceivedEmailAttachmentDetails:
+    def get(cls, email_id: str, attachment_id: str) -> EmailAttachmentDetails:
         """
         Retrieve a single attachment from a sent email.
         see more: https://resend.com/docs/api-reference/attachments/retrieve-attachment
@@ -74,10 +74,10 @@ class Attachments:
             attachment_id (str): The ID of the attachment to retrieve
 
         Returns:
-            ReceivedEmailAttachmentDetails: The attachment details including download URL
+            EmailAttachmentDetails: The attachment details including download URL
         """
         path = f"/emails/{email_id}/attachments/{attachment_id}"
-        resp = request.Request[ReceivedEmailAttachmentDetails](
+        resp = request.Request[EmailAttachmentDetails](
             path=path,
             params={},
             verb="get",

--- a/resend/emails/_attachments.py
+++ b/resend/emails/_attachments.py
@@ -8,12 +8,6 @@ from resend.emails._received_email import (ReceivedEmailAttachment,
 from resend.pagination_helper import PaginationHelper
 
 
-# Internal wrapper type for get attachment API response
-class _GetAttachmentResponse(TypedDict):
-    object: str
-    data: ReceivedEmailAttachmentDetails
-
-
 class _ListParams(TypedDict):
     limit: NotRequired[int]
     """
@@ -44,9 +38,9 @@ class _ListResponse(TypedDict):
     """
 
 
-class Receiving:
+class Attachments:
     """
-    Receiving class that provides methods for retrieving attachments from received emails.
+    Attachments class that provides methods for retrieving attachments from sent emails.
     """
 
     class ListParams(_ListParams):
@@ -72,42 +66,41 @@ class Receiving:
     @classmethod
     def get(cls, email_id: str, attachment_id: str) -> ReceivedEmailAttachmentDetails:
         """
-        Retrieve a single attachment from a received email.
+        Retrieve a single attachment from a sent email.
         see more: https://resend.com/docs/api-reference/attachments/retrieve-attachment
 
         Args:
-            email_id (str): The ID of the received email
+            email_id (str): The ID of the sent email
             attachment_id (str): The ID of the attachment to retrieve
 
         Returns:
             ReceivedEmailAttachmentDetails: The attachment details including download URL
         """
-        path = f"/emails/receiving/{email_id}/attachments/{attachment_id}"
-        resp = request.Request[_GetAttachmentResponse](
+        path = f"/emails/{email_id}/attachments/{attachment_id}"
+        resp = request.Request[ReceivedEmailAttachmentDetails](
             path=path,
             params={},
             verb="get",
         ).perform_with_content()
-        # Extract the data field from the wrapped response
-        return resp["data"]
+        return resp
 
     @classmethod
     def list(cls, email_id: str, params: Optional[ListParams] = None) -> ListResponse:
         """
-        Retrieve a list of attachments from a received email.
+        Retrieve a list of attachments from a sent email.
         see more: https://resend.com/docs/api-reference/attachments/list-attachments
 
         Args:
-            email_id (str): The ID of the received email
+            email_id (str): The ID of the sent email
             params (Optional[ListParams]): The list parameters for pagination
 
         Returns:
             ListResponse: A paginated list of attachment objects
         """
-        base_path = f"/emails/receiving/{email_id}/attachments"
+        base_path = f"/emails/{email_id}/attachments"
         query_params = cast(Dict[Any, Any], params) if params else None
         path = PaginationHelper.build_paginated_path(base_path, query_params)
-        resp = request.Request[Receiving.ListResponse](
+        resp = request.Request[Attachments.ListResponse](
             path=path,
             params={},
             verb="get",

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -4,6 +4,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from resend import request
 from resend.emails._attachment import Attachment, RemoteAttachment
+from resend.emails._attachments import Attachments
 from resend.emails._email import Email
 from resend.emails._receiving import Receiving
 from resend.emails._tag import Tag
@@ -104,6 +105,7 @@ class _SendParamsDefault(_SendParamsFrom):
 
 
 class Emails:
+    Attachments = Attachments
     Receiving = Receiving
 
     class CancelScheduledEmailResponse(_CancelScheduledEmailResponse):

--- a/resend/emails/_received_email.py
+++ b/resend/emails/_received_email.py
@@ -3,9 +3,9 @@ from typing import Dict, List, Optional
 from typing_extensions import NotRequired, TypedDict
 
 
-class ReceivedEmailAttachment(TypedDict):
+class EmailAttachment(TypedDict):
     """
-    ReceivedEmailAttachment type that wraps an attachment object from a received email.
+    EmailAttachment type that wraps an attachment object from an email.
 
     Attributes:
         id (str): The attachment ID.
@@ -42,9 +42,9 @@ class ReceivedEmailAttachment(TypedDict):
     """
 
 
-class ReceivedEmailAttachmentDetails(TypedDict):
+class EmailAttachmentDetails(TypedDict):
     """
-    ReceivedEmailAttachmentDetails type that wraps a received email attachment with download details.
+    EmailAttachmentDetails type that wraps an email attachment with download details.
 
     Attributes:
         object (str): The object type.
@@ -158,7 +158,7 @@ class _ReceivedEmailDefaultAttrs(_ReceivedEmailFromParam):
     """
     Email headers.
     """
-    attachments: List[ReceivedEmailAttachment]
+    attachments: List[EmailAttachment]
     """
     List of attachments.
     """
@@ -182,7 +182,7 @@ class ReceivedEmail(_ReceivedEmailDefaultAttrs):
         reply_to (Optional[List[str]]): Reply-to addresses.
         message_id (str): The message ID of the email.
         headers (NotRequired[Dict[str, str]]): Email headers.
-        attachments (List[ReceivedEmailAttachment]): List of attachments.
+        attachments (List[EmailAttachment]): List of attachments.
     """
 
 
@@ -219,7 +219,7 @@ class _ListReceivedEmailDefaultAttrs(_ListReceivedEmailFromParam):
     """
     The message ID of the email.
     """
-    attachments: List[ReceivedEmailAttachment]
+    attachments: List[EmailAttachment]
     """
     List of attachments.
     """
@@ -240,5 +240,5 @@ class ListReceivedEmail(_ListReceivedEmailDefaultAttrs):
         cc (Optional[List[str]]): Cc recipients.
         reply_to (Optional[List[str]]): Reply-to addresses.
         message_id (str): The message ID of the email.
-        attachments (List[ReceivedEmailAttachment]): List of attachments.
+        attachments (List[EmailAttachment]): List of attachments.
     """

--- a/resend/emails/_received_email.py
+++ b/resend/emails/_received_email.py
@@ -47,6 +47,7 @@ class ReceivedEmailAttachmentDetails(TypedDict):
     ReceivedEmailAttachmentDetails type that wraps a received email attachment with download details.
 
     Attributes:
+        object (str): The object type.
         id (str): The attachment ID.
         filename (str): The filename of the attachment.
         content_type (str): The content type of the attachment.
@@ -56,6 +57,10 @@ class ReceivedEmailAttachmentDetails(TypedDict):
         expires_at (str): When the download URL expires.
     """
 
+    object: str
+    """
+    The object type.
+    """
     id: str
     """
     The attachment ID.

--- a/resend/emails/_receiving.py
+++ b/resend/emails/_receiving.py
@@ -3,7 +3,9 @@ from typing import Any, Dict, List, Optional, cast
 from typing_extensions import NotRequired, TypedDict
 
 from resend import request
-from resend.emails._received_email import ListReceivedEmail, ReceivedEmail
+from resend.emails._received_email import (ListReceivedEmail, ReceivedEmail,
+                                           ReceivedEmailAttachment,
+                                           ReceivedEmailAttachmentDetails)
 from resend.pagination_helper import PaginationHelper
 
 
@@ -37,10 +39,113 @@ class _ListResponse(TypedDict):
     """
 
 
+class _AttachmentListParams(TypedDict):
+    limit: NotRequired[int]
+    """
+    The maximum number of attachments to return. Maximum 100, minimum 1.
+    """
+    after: NotRequired[str]
+    """
+    Return attachments after this cursor for pagination.
+    """
+    before: NotRequired[str]
+    """
+    Return attachments before this cursor for pagination.
+    """
+
+
+class _AttachmentListResponse(TypedDict):
+    object: str
+    """
+    The object type: "list"
+    """
+    data: List[ReceivedEmailAttachment]
+    """
+    The list of attachment objects.
+    """
+    has_more: bool
+    """
+    Whether there are more attachments available for pagination.
+    """
+
+
 class Receiving:
     """
     Receiving class that provides methods for retrieving received (inbound) emails.
     """
+
+    class Attachments:
+        """
+        Attachments class that provides methods for retrieving attachments from received emails.
+        """
+
+        class ListParams(_AttachmentListParams):
+            """
+            ListParams is the class that wraps the parameters for the list method.
+
+            Attributes:
+                limit (NotRequired[int]): The maximum number of attachments to return. Maximum 100, minimum 1.
+                after (NotRequired[str]): Return attachments after this cursor for pagination.
+                before (NotRequired[str]): Return attachments before this cursor for pagination.
+            """
+
+        class ListResponse(_AttachmentListResponse):
+            """
+            ListResponse is the type that wraps the response for listing attachments.
+
+            Attributes:
+                object (str): The object type: "list"
+                data (List[ReceivedEmailAttachment]): The list of attachment objects.
+                has_more (bool): Whether there are more attachments available for pagination.
+            """
+
+        @classmethod
+        def get(cls, email_id: str, attachment_id: str) -> ReceivedEmailAttachmentDetails:
+            """
+            Retrieve a single attachment from a received email.
+            see more: https://resend.com/docs/api-reference/attachments/retrieve-attachment
+
+            Args:
+                email_id (str): The ID of the received email
+                attachment_id (str): The ID of the attachment to retrieve
+
+            Returns:
+                ReceivedEmailAttachmentDetails: The attachment details including download URL
+            """
+            path = f"/emails/receiving/{email_id}/attachments/{attachment_id}"
+            resp = request.Request[ReceivedEmailAttachmentDetails](
+                path=path,
+                params={},
+                verb="get",
+            ).perform_with_content()
+            return resp
+
+        @classmethod
+        def list(
+            cls,
+            email_id: str,
+            params: Optional["Receiving.Attachments.ListParams"] = None,
+        ) -> "Receiving.Attachments.ListResponse":
+            """
+            Retrieve a list of attachments from a received email.
+            see more: https://resend.com/docs/api-reference/attachments/list-attachments
+
+            Args:
+                email_id (str): The ID of the received email
+                params (Optional[ListParams]): The list parameters for pagination
+
+            Returns:
+                ListResponse: A paginated list of attachment objects
+            """
+            base_path = f"/emails/receiving/{email_id}/attachments"
+            query_params = cast(Dict[Any, Any], params) if params else None
+            path = PaginationHelper.build_paginated_path(base_path, query_params)
+            resp = request.Request[_AttachmentListResponse](
+                path=path,
+                params={},
+                verb="get",
+            ).perform_with_content()
+            return resp
 
     class ListParams(_ListParams):
         """

--- a/resend/emails/_receiving.py
+++ b/resend/emails/_receiving.py
@@ -103,7 +103,7 @@ class Receiving:
         def get(cls, email_id: str, attachment_id: str) -> EmailAttachmentDetails:
             """
             Retrieve a single attachment from a received email.
-            see more: https://resend.com/docs/api-reference/attachments/retrieve-attachment
+            see more: https://resend.com/docs/api-reference/attachments/retrieve-received-email-attachment
 
             Args:
                 email_id (str): The ID of the received email
@@ -128,7 +128,7 @@ class Receiving:
         ) -> "Receiving.Attachments.ListResponse":
             """
             Retrieve a list of attachments from a received email.
-            see more: https://resend.com/docs/api-reference/attachments/list-attachments
+            see more: https://resend.com/docs/api-reference/attachments/list-received-email-attachments
 
             Args:
                 email_id (str): The ID of the received email

--- a/resend/emails/_receiving.py
+++ b/resend/emails/_receiving.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Optional, cast
 from typing_extensions import NotRequired, TypedDict
 
 from resend import request
-from resend.emails._received_email import (ListReceivedEmail, ReceivedEmail,
-                                           ReceivedEmailAttachment,
-                                           ReceivedEmailAttachmentDetails)
+from resend.emails._received_email import (EmailAttachment,
+                                           EmailAttachmentDetails,
+                                           ListReceivedEmail, ReceivedEmail)
 from resend.pagination_helper import PaginationHelper
 
 
@@ -59,7 +59,7 @@ class _AttachmentListResponse(TypedDict):
     """
     The object type: "list"
     """
-    data: List[ReceivedEmailAttachment]
+    data: List[EmailAttachment]
     """
     The list of attachment objects.
     """
@@ -95,12 +95,12 @@ class Receiving:
 
             Attributes:
                 object (str): The object type: "list"
-                data (List[ReceivedEmailAttachment]): The list of attachment objects.
+                data (List[EmailAttachment]): The list of attachment objects.
                 has_more (bool): Whether there are more attachments available for pagination.
             """
 
         @classmethod
-        def get(cls, email_id: str, attachment_id: str) -> ReceivedEmailAttachmentDetails:
+        def get(cls, email_id: str, attachment_id: str) -> EmailAttachmentDetails:
             """
             Retrieve a single attachment from a received email.
             see more: https://resend.com/docs/api-reference/attachments/retrieve-attachment
@@ -110,10 +110,10 @@ class Receiving:
                 attachment_id (str): The ID of the attachment to retrieve
 
             Returns:
-                ReceivedEmailAttachmentDetails: The attachment details including download URL
+                EmailAttachmentDetails: The attachment details including download URL
             """
             path = f"/emails/receiving/{email_id}/attachments/{attachment_id}"
-            resp = request.Request[ReceivedEmailAttachmentDetails](
+            resp = request.Request[EmailAttachmentDetails](
                 path=path,
                 params={},
                 verb="get",

--- a/tests/attachments_test.py
+++ b/tests/attachments_test.py
@@ -22,7 +22,7 @@ class TestResendAttachments(ResendBaseTest):
             }
         )
 
-        attachment: resend.ReceivedEmailAttachmentDetails = (
+        attachment: resend.EmailAttachmentDetails = (
             resend.Emails.Receiving.Attachments.get(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
                 attachment_id="2a0c9ce0-3112-4728-976e-47ddcd16a318",
@@ -50,7 +50,7 @@ class TestResendAttachments(ResendBaseTest):
             }
         )
 
-        attachment: resend.ReceivedEmailAttachmentDetails = (
+        attachment: resend.EmailAttachmentDetails = (
             resend.Emails.Receiving.Attachments.get(
                 email_id="test-email-id",
                 attachment_id="3b1c9ce0-4223-5839-a87f-58eecd27b429",

--- a/tests/attachments_test.py
+++ b/tests/attachments_test.py
@@ -1,5 +1,5 @@
 import resend
-from resend import AttachmentsReceiving
+from resend import EmailsReceiving
 from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
@@ -11,26 +11,25 @@ class TestResendAttachments(ResendBaseTest):
     def test_receiving_get_attachment(self) -> None:
         self.set_mock_json(
             {
+                "id": "2a0c9ce0-3112-4728-976e-47ddcd16a318",
                 "object": "attachment",
-                "data": {
-                    "id": "2a0c9ce0-3112-4728-976e-47ddcd16a318",
-                    "filename": "avatar.png",
-                    "content_type": "image/png",
-                    "content_disposition": "inline",
-                    "content_id": "img001",
-                    "download_url": "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
-                    "expires_at": "2025-10-17T14:29:41.521Z",
-                },
+                "filename": "avatar.png",
+                "content_type": "image/png",
+                "content_disposition": "inline",
+                "content_id": "img001",
+                "download_url": "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
+                "expires_at": "2025-10-17T14:29:41.521Z",
             }
         )
 
         attachment: resend.ReceivedEmailAttachmentDetails = (
-            resend.Attachments.Receiving.get(
+            resend.Emails.Receiving.Attachments.get(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
                 attachment_id="2a0c9ce0-3112-4728-976e-47ddcd16a318",
             )
         )
         assert attachment["id"] == "2a0c9ce0-3112-4728-976e-47ddcd16a318"
+        assert attachment["object"] == "attachment"
         assert attachment["filename"] == "avatar.png"
         assert attachment["content_type"] == "image/png"
         assert attachment["content_disposition"] == "inline"
@@ -41,25 +40,24 @@ class TestResendAttachments(ResendBaseTest):
     def test_receiving_get_attachment_without_content_id(self) -> None:
         self.set_mock_json(
             {
+                "id": "3b1c9ce0-4223-5839-a87f-58eecd27b429",
                 "object": "attachment",
-                "data": {
-                    "id": "3b1c9ce0-4223-5839-a87f-58eecd27b429",
-                    "filename": "document.pdf",
-                    "content_type": "application/pdf",
-                    "content_disposition": "attachment",
-                    "download_url": "https://inbound-cdn.resend.com/test-email/attachments/test-attachment",
-                    "expires_at": "2025-10-18T10:00:00.000Z",
-                },
+                "filename": "document.pdf",
+                "content_type": "application/pdf",
+                "content_disposition": "attachment",
+                "download_url": "https://inbound-cdn.resend.com/test-email/attachments/test-attachment",
+                "expires_at": "2025-10-18T10:00:00.000Z",
             }
         )
 
         attachment: resend.ReceivedEmailAttachmentDetails = (
-            resend.Attachments.Receiving.get(
+            resend.Emails.Receiving.Attachments.get(
                 email_id="test-email-id",
                 attachment_id="3b1c9ce0-4223-5839-a87f-58eecd27b429",
             )
         )
         assert attachment["id"] == "3b1c9ce0-4223-5839-a87f-58eecd27b429"
+        assert attachment["object"] == "attachment"
         assert attachment["filename"] == "document.pdf"
         assert attachment["content_type"] == "application/pdf"
         assert attachment["content_disposition"] == "attachment"
@@ -70,7 +68,7 @@ class TestResendAttachments(ResendBaseTest):
     ) -> None:
         self.set_mock_json(None)
         with self.assertRaises(NoContentError):
-            _ = resend.Attachments.Receiving.get(
+            _ = resend.Emails.Receiving.Attachments.get(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
                 attachment_id="2a0c9ce0-3112-4728-976e-47ddcd16a318",
             )
@@ -100,8 +98,8 @@ class TestResendAttachments(ResendBaseTest):
             }
         )
 
-        attachments: AttachmentsReceiving.ListResponse = (
-            resend.Attachments.Receiving.list(
+        attachments: EmailsReceiving.Attachments.ListResponse = (
+            resend.Emails.Receiving.Attachments.list(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
             )
         )
@@ -132,11 +130,11 @@ class TestResendAttachments(ResendBaseTest):
             }
         )
 
-        list_params: AttachmentsReceiving.ListParams = {
+        list_params: EmailsReceiving.Attachments.ListParams = {
             "limit": 1,
         }
-        attachments: AttachmentsReceiving.ListResponse = (
-            resend.Attachments.Receiving.list(
+        attachments: EmailsReceiving.Attachments.ListResponse = (
+            resend.Emails.Receiving.Attachments.list(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c", params=list_params
             )
         )
@@ -154,8 +152,8 @@ class TestResendAttachments(ResendBaseTest):
             }
         )
 
-        attachments: AttachmentsReceiving.ListResponse = (
-            resend.Attachments.Receiving.list(
+        attachments: EmailsReceiving.Attachments.ListResponse = (
+            resend.Emails.Receiving.Attachments.list(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
             )
         )
@@ -169,6 +167,6 @@ class TestResendAttachments(ResendBaseTest):
     ) -> None:
         self.set_mock_json(None)
         with self.assertRaises(NoContentError):
-            _ = resend.Attachments.Receiving.list(
+            _ = resend.Emails.Receiving.Attachments.list(
                 email_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
             )


### PR DESCRIPTION
This updates the API for the inbound methods on this SDK to conform to the new specification.

Note that I also fixed an incorrect wrapping in `data` that I ended up missing from the first review.

This is as per @vieiralucas message's from Monday:

> Hey folks,
> We recently changed how we are calling the methods related to attachments on the Node SDK
> resend.attachments.sending     →  resend.emails.attachments
> resend.attachments.receiving →  resend.emails.receiving.attachments
>
> If you already had implemented those in your language, you might want to check if it makes sense to adjust them.
>
> We also changed the attachment routes for sending:
> From: GET /emails/sending/:emailId/attachments
> To:   GET /emails/:emailId/attachments
>
> From: GET /emails/sending/:emailId/attachments/:attachmentId
> To:   GET /emails/:emailId/attachments/:attachmentId
>
> Basically, removed the /sending/. We're not removing the old endpoints from the API, but you must change the SDK to call the new one.

In Python, that means we now have:

```
# Attachments for sent emails (added)
sent_attachments_list = resend.Emails.Attachments.list(email_id=sent_email_id)
    sent_attachment_details = resend.Emails.Attachments.get(
        email_id=sent_email_id,
        attachment_id=first_attachment_id
    )

# Attachments for received emails (now nested inside `Receiving`)
received_attachments = resend.Emails.Receiving.Attachments.list(email_id=last_email_id)
received_attachment_details = resend.Emails.Receiving.Attachments.get(
    email_id=last_email_id,
    attachment_id=received_attachment_id
)
```

---

## What I need from you

Please review/test my changes carefully. I have already created a test file locally to test all these functions, but please do test it too.

If you need to make any changes, please go ahead and make commits to this PR.

**Once done, please let's release a new version with these changes.** I'm not sure if you have already released a version with this, but please do once you merge this (let's avoid releasing the old SDK API if it's not released yet just to avoid a major bump if possible).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the attachments API to match the new spec. Attachment methods are now under resend.Emails and responses return the attachment object directly (no data wrapper).

- **Refactors**
  - Sent attachments: resend.Emails.Attachments.list/get → calls /emails/:emailId/attachments and /emails/:emailId/attachments/:attachmentId.
  - Received attachments: moved to resend.Emails.Receiving.Attachments.
  - Removed the old resend.attachments module and exports; Emails exposes Attachments via resend.Emails.Attachments.
  - Updated examples and tests to the new structure and response shape.

- **Migration**
  - Replace imports: resend.Attachments.Receiving → resend.Emails.Receiving.Attachments.
  - Use resend.Emails.Attachments for sent email attachments.
  - Expect a direct attachment object in get responses (no data field).

<!-- End of auto-generated description by cubic. -->

