### PR TITLE
chore: Bump to v2.18.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.17.0"
+__version__ = "2.18.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped package version to 2.18.0 to prepare for the next release. Updates __version__ in resend/version.py so the correct version is reported.

<!-- End of auto-generated description by cubic. -->

