### PR TITLE
feat: contact properties implementation + contact topics get/update

### DIFF
--- a/examples/contact_properties.py
+++ b/examples/contact_properties.py
@@ -1,0 +1,33 @@
+import resend
+import os
+
+if not os.environ["RESEND_API_KEY"]:
+    raise EnvironmentError("RESEND_API_KEY is missing")
+
+create_response = resend.ContactProperties.create(
+    {
+        "key": "age",
+        "type": "number",
+        "fallback_value": 0,
+    }
+)
+print(f"Created contact property: {create_response}")
+
+list_response = resend.ContactProperties.list()
+print(f"Contact properties: {list_response}")
+
+paginated_response = resend.ContactProperties.list({"limit": 10})
+print(f"Limited contact properties: {paginated_response}")
+print(f"Has more: {paginated_response.get('has_more', False)}")
+
+property_id = create_response["id"]
+property_details = resend.ContactProperties.get(property_id)
+print(f"Contact property details: {property_details}")
+
+update_response = resend.ContactProperties.update(
+    {"id": property_id, "fallback_value": 18}
+)
+print(f"Updated contact property: {update_response}")
+
+remove_response = resend.ContactProperties.remove(property_id)
+print(f"Removed contact property: {remove_response}")

--- a/examples/contact_properties.py
+++ b/examples/contact_properties.py
@@ -5,30 +5,46 @@ import resend
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
-create_response = resend.ContactProperties.create(
-    {
-        "key": "age",
-        "type": "number",
-        "fallback_value": 0,
-    }
+# Create a contact property
+create_params: resend.ContactProperties.CreateParams = {
+    "key": "age",
+    "type": "number",
+    "fallback_value": 0,
+}
+create_response: resend.ContactProperties.CreateResponse = (
+    resend.ContactProperties.create(create_params)
 )
 print(f"Created contact property: {create_response}")
 
-list_response = resend.ContactProperties.list()
+# List all contact properties
+list_response: resend.ContactProperties.ListResponse = resend.ContactProperties.list()
 print(f"Contact properties: {list_response}")
 
-paginated_response = resend.ContactProperties.list({"limit": 10})
+# List with pagination
+list_params: resend.ContactProperties.ListParams = {"limit": 10}
+paginated_response: resend.ContactProperties.ListResponse = (
+    resend.ContactProperties.list(list_params)
+)
 print(f"Limited contact properties: {paginated_response}")
 print(f"Has more: {paginated_response.get('has_more', False)}")
 
-property_id = create_response["id"]
-property_details = resend.ContactProperties.get(property_id)
+# Get a specific contact property
+property_id: str = create_response["id"]
+property_details: resend.ContactProperty = resend.ContactProperties.get(property_id)
 print(f"Contact property details: {property_details}")
 
-update_response = resend.ContactProperties.update(
-    {"id": property_id, "fallback_value": 18}
+# Update a contact property
+update_params: resend.ContactProperties.UpdateParams = {
+    "id": property_id,
+    "fallback_value": 18,
+}
+update_response: resend.ContactProperties.UpdateResponse = (
+    resend.ContactProperties.update(update_params)
 )
 print(f"Updated contact property: {update_response}")
 
-remove_response = resend.ContactProperties.remove(property_id)
+# Remove a contact property
+remove_response: resend.ContactProperties.RemoveResponse = (
+    resend.ContactProperties.remove(property_id)
+)
 print(f"Removed contact property: {remove_response}")

--- a/examples/contact_properties.py
+++ b/examples/contact_properties.py
@@ -1,5 +1,6 @@
-import resend
 import os
+
+import resend
 
 if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")

--- a/examples/contacts.py
+++ b/examples/contacts.py
@@ -65,6 +65,81 @@ if contacts["data"]:
 else:
     print("No contacts available for pagination example")
 
+print("\n--- Contact Topics Examples ---")
+
+print("\nCreating a topic...")
+topic_create_params: resend.Topics.CreateParams = {
+    "name": "Product Updates",
+    "default_subscription": "opt_in",
+    "description": "Latest product updates and features",
+}
+created_topic: resend.Topics.CreateTopicResponse = resend.Topics.create(topic_create_params)
+print(f"Created topic with ID: {created_topic['id']}")
+
+topic_create_params_2: resend.Topics.CreateParams = {
+    "name": "Newsletter",
+    "default_subscription": "opt_out",
+    "description": "Weekly newsletter",
+}
+created_topic_2: resend.Topics.CreateTopicResponse = resend.Topics.create(topic_create_params_2)
+print(f"Created topic with ID: {created_topic_2['id']}")
+
+print("\nListing topics for contact by ID...")
+topics_response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+    contact_id=contact["id"]
+)
+print(f"Found {len(topics_response['data'])} topics for contact")
+for topic in topics_response["data"]:
+    print(f"  - {topic['name']}: {topic['subscription']}")
+
+print("\nListing topics for contact by email...")
+topics_by_email: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+    email="sw@exmple.com"
+)
+print(f"Found {len(topics_by_email['data'])} topics for contact")
+
+# Update topic subscriptions for a contact by ID
+print("\nUpdating topic subscriptions by contact ID...")
+update_topics_params: resend.Contacts.Topics.UpdateParams = {
+    "id": contact["id"],
+    "topics": [
+        {"id": created_topic["id"], "subscription": "opt_in"},
+        {"id": created_topic_2["id"], "subscription": "opt_out"},
+    ],
+}
+update_topics_response: resend.Contacts.Topics.UpdateResponse = (
+    resend.Contacts.Topics.update(update_topics_params)
+)
+print(f"Updated topics for contact: {update_topics_response['id']}")
+
+# Update topic subscriptions for a contact by email
+print("\nUpdating topic subscriptions by contact email...")
+update_topics_by_email: resend.Contacts.Topics.UpdateParams = {
+    "email": "sw@exmple.com",
+    "topics": [
+        {"id": created_topic["id"], "subscription": "opt_in"},
+        {"id": created_topic_2["id"], "subscription": "opt_in"},
+    ],
+}
+update_by_email_response: resend.Contacts.Topics.UpdateResponse = (
+    resend.Contacts.Topics.update(update_topics_by_email)
+)
+print(f"Updated topics for contact by email: {update_by_email_response['id']}")
+
+# List topics again to see the updates
+print("\nListing topics after updates...")
+updated_topics: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+    contact_id=contact["id"]
+)
+for topic in updated_topics["data"]:
+    print(f"  - {topic['name']}: {topic['subscription']}")
+
+# Clean up: remove the topics we created
+print("\nCleaning up topics...")
+resend.Topics.remove(created_topic["id"])
+resend.Topics.remove(created_topic_2["id"])
+print("Topics removed")
+
 # remove by email
 rmed: resend.Contacts.RemoveContactResponse = resend.Contacts.remove(
     audience_id=audience_id, email=cont_by_email["email"]

--- a/examples/contacts.py
+++ b/examples/contacts.py
@@ -73,7 +73,9 @@ topic_create_params: resend.Topics.CreateParams = {
     "default_subscription": "opt_in",
     "description": "Latest product updates and features",
 }
-created_topic: resend.Topics.CreateTopicResponse = resend.Topics.create(topic_create_params)
+created_topic: resend.Topics.CreateTopicResponse = resend.Topics.create(
+    topic_create_params
+)
 print(f"Created topic with ID: {created_topic['id']}")
 
 topic_create_params_2: resend.Topics.CreateParams = {
@@ -81,11 +83,13 @@ topic_create_params_2: resend.Topics.CreateParams = {
     "default_subscription": "opt_out",
     "description": "Weekly newsletter",
 }
-created_topic_2: resend.Topics.CreateTopicResponse = resend.Topics.create(topic_create_params_2)
+created_topic_2: resend.Topics.CreateTopicResponse = resend.Topics.create(
+    topic_create_params_2
+)
 print(f"Created topic with ID: {created_topic_2['id']}")
 
 print("\nListing topics for contact by ID...")
-topics_response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+topics_response: resend.ContactsTopics.ListResponse = resend.Contacts.Topics.list(
     contact_id=contact["id"]
 )
 print(f"Found {len(topics_response['data'])} topics for contact")
@@ -93,42 +97,42 @@ for topic in topics_response["data"]:
     print(f"  - {topic['name']}: {topic['subscription']}")
 
 print("\nListing topics for contact by email...")
-topics_by_email: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+topics_by_email: resend.ContactsTopics.ListResponse = resend.Contacts.Topics.list(
     email="sw@exmple.com"
 )
 print(f"Found {len(topics_by_email['data'])} topics for contact")
 
 # Update topic subscriptions for a contact by ID
 print("\nUpdating topic subscriptions by contact ID...")
-update_topics_params: resend.Contacts.Topics.UpdateParams = {
+update_topics_params: resend.ContactsTopics.UpdateParams = {
     "id": contact["id"],
     "topics": [
         {"id": created_topic["id"], "subscription": "opt_in"},
         {"id": created_topic_2["id"], "subscription": "opt_out"},
     ],
 }
-update_topics_response: resend.Contacts.Topics.UpdateResponse = (
+update_topics_response: resend.ContactsTopics.UpdateResponse = (
     resend.Contacts.Topics.update(update_topics_params)
 )
 print(f"Updated topics for contact: {update_topics_response['id']}")
 
 # Update topic subscriptions for a contact by email
 print("\nUpdating topic subscriptions by contact email...")
-update_topics_by_email: resend.Contacts.Topics.UpdateParams = {
+update_topics_by_email: resend.ContactsTopics.UpdateParams = {
     "email": "sw@exmple.com",
     "topics": [
         {"id": created_topic["id"], "subscription": "opt_in"},
         {"id": created_topic_2["id"], "subscription": "opt_in"},
     ],
 }
-update_by_email_response: resend.Contacts.Topics.UpdateResponse = (
+update_by_email_response: resend.ContactsTopics.UpdateResponse = (
     resend.Contacts.Topics.update(update_topics_by_email)
 )
 print(f"Updated topics for contact by email: {update_by_email_response['id']}")
 
 # List topics again to see the updates
 print("\nListing topics after updates...")
-updated_topics: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+updated_topics: resend.ContactsTopics.ListResponse = resend.Contacts.Topics.list(
     contact_id=contact["id"]
 )
 for topic in updated_topics["data"]:

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -6,8 +6,8 @@ from .audiences._audience import Audience
 from .audiences._audiences import Audiences
 from .broadcasts._broadcast import Broadcast
 from .broadcasts._broadcasts import Broadcasts
-from .contact_properties._contact_property import ContactProperty
 from .contact_properties._contact_properties import ContactProperties
+from .contact_properties._contact_property import ContactProperty
 from .contacts._contact import Contact
 from .contacts._contact_topic import ContactTopic, TopicSubscriptionUpdate
 from .contacts._contacts import Contacts

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -6,8 +6,12 @@ from .audiences._audience import Audience
 from .audiences._audiences import Audiences
 from .broadcasts._broadcast import Broadcast
 from .broadcasts._broadcasts import Broadcasts
+from .contact_properties._contact_property import ContactProperty
+from .contact_properties._contact_properties import ContactProperties
 from .contacts._contact import Contact
+from .contacts._contact_topic import ContactTopic, TopicSubscriptionUpdate
 from .contacts._contacts import Contacts
+from .contacts._topics import Topics as ContactsTopics
 from .domains._domain import Domain
 from .domains._domains import Domains
 from .emails._attachment import Attachment, RemoteAttachment
@@ -48,6 +52,7 @@ __all__ = [
     "Batch",
     "Audiences",
     "Contacts",
+    "ContactProperties",
     "Broadcasts",
     "Templates",
     "Webhooks",
@@ -55,6 +60,9 @@ __all__ = [
     # Types
     "Audience",
     "Contact",
+    "ContactProperty",
+    "ContactTopic",
+    "TopicSubscriptionUpdate",
     "Domain",
     "ApiKey",
     "Email",
@@ -80,6 +88,7 @@ __all__ = [
     # Receiving types (for type hints)
     "EmailsReceiving",
     "EmailAttachments",
+    "ContactsTopics",
     # Default HTTP Client
     "RequestsClient",
 ]

--- a/resend/contact_properties/_contact_properties.py
+++ b/resend/contact_properties/_contact_properties.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -126,7 +126,7 @@ class ContactProperties:
         Attributes:
             key (str): The key name of the property
             type (str): The data type of the property (e.g., "string", "number", "boolean")
-            fallback_value (Any): The default value used when a contact doesn't have this property set
+            fallback_value (NotRequired[Any]): The default value used when a contact doesn't have this property set
         """
 
         key: str
@@ -137,9 +137,10 @@ class ContactProperties:
         """
         The data type of the property (e.g., "string", "number", "boolean").
         """
-        fallback_value: Any
+        fallback_value: NotRequired[Union[str, int, float, None]]
         """
         The default value used when a contact doesn't have this property set.
+        Must match the type specified in the type field (string or number).
         """
 
     class UpdateParams(TypedDict):
@@ -148,16 +149,17 @@ class ContactProperties:
 
         Attributes:
             id (str): The contact property ID
-            fallback_value (Any): The default value used when a contact doesn't have this property set
+            fallback_value (Union[str, int, float, None]): The default value used when a contact doesn't have this property set
         """
 
         id: str
         """
         The contact property ID.
         """
-        fallback_value: Any
+        fallback_value: Union[str, int, float, None]
         """
         The default value used when a contact doesn't have this property set.
+        Must match the type of the property (string or number).
         """
 
     @classmethod
@@ -233,8 +235,11 @@ class ContactProperties:
             UpdateResponse: The updated contact property response
         """
         path = f"/contact-properties/{params['id']}"
+        # Build the payload without id (it's only used in the URL path)
+        payload: Dict[str, Any] = {"fallback_value": params["fallback_value"]}
+
         resp = request.Request[ContactProperties.UpdateResponse](
-            path=path, params=cast(Dict[Any, Any], params), verb="patch"
+            path=path, params=payload, verb="patch"
         ).perform_with_content()
         return resp
 

--- a/resend/contact_properties/_contact_properties.py
+++ b/resend/contact_properties/_contact_properties.py
@@ -1,0 +1,257 @@
+from typing import Any, Dict, List, Optional, cast
+
+from typing_extensions import NotRequired, TypedDict
+
+from resend import request
+from resend.pagination_helper import PaginationHelper
+
+from ._contact_property import ContactProperty
+
+
+class ContactProperties:
+
+    class CreateResponse(TypedDict):
+        """
+        CreateResponse is the type that wraps the response of the contact property that was created.
+
+        Attributes:
+            id (str): The ID of the created contact property
+            object (str): The object type, always "contact_property"
+        """
+
+        id: str
+        """
+        The ID of the created contact property.
+        """
+        object: str
+        """
+        The object type, always "contact_property".
+        """
+
+    class UpdateResponse(TypedDict):
+        """
+        UpdateResponse is the type that wraps the response of the contact property that was updated.
+
+        Attributes:
+            id (str): The ID of the updated contact property
+            object (str): The object type, always "contact_property"
+        """
+
+        id: str
+        """
+        The ID of the updated contact property.
+        """
+        object: str
+        """
+        The object type, always "contact_property".
+        """
+
+    class RemoveResponse(TypedDict):
+        """
+        RemoveResponse is the type that wraps the response of the contact property that was removed.
+
+        Attributes:
+            id (str): The ID of the removed contact property
+            object (str): The object type, always "contact_property"
+            deleted (bool): Whether the contact property was deleted
+        """
+
+        id: str
+        """
+        The ID of the removed contact property.
+        """
+        object: str
+        """
+        The object type, always "contact_property".
+        """
+        deleted: bool
+        """
+        Whether the contact property was deleted.
+        """
+
+    class ListParams(TypedDict):
+        """
+        ListParams is the class that wraps the parameters for the list method.
+
+        Attributes:
+            limit (NotRequired[int]): Number of contact properties to retrieve. Maximum is 100, minimum is 1.
+            after (NotRequired[str]): The ID after which we'll retrieve more contact properties (for pagination).
+            before (NotRequired[str]): The ID before which we'll retrieve more contact properties (for pagination).
+        """
+
+        limit: NotRequired[int]
+        """
+        Number of contact properties to retrieve. Maximum is 100, minimum is 1.
+        """
+        after: NotRequired[str]
+        """
+        The ID after which we'll retrieve more contact properties (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the before parameter.
+        """
+        before: NotRequired[str]
+        """
+        The ID before which we'll retrieve more contact properties (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the after parameter.
+        """
+
+    class ListResponse(TypedDict):
+        """
+        ListResponse type that wraps a list of contact property objects with pagination metadata.
+
+        Attributes:
+            object (str): The object type, always "list"
+            data (List[ContactProperty]): A list of contact property objects
+            has_more (bool): Whether there are more results available
+        """
+
+        object: str
+        """
+        The object type, always "list".
+        """
+        data: List[ContactProperty]
+        """
+        A list of contact property objects.
+        """
+        has_more: bool
+        """
+        Whether there are more results available for pagination.
+        """
+
+    class CreateParams(TypedDict):
+        """
+        CreateParams is the class that wraps the parameters for creating a contact property.
+
+        Attributes:
+            key (str): The key name of the property
+            type (str): The data type of the property (e.g., "string", "number", "boolean")
+            fallback_value (Any): The default value used when a contact doesn't have this property set
+        """
+
+        key: str
+        """
+        The key name of the property.
+        """
+        type: str
+        """
+        The data type of the property (e.g., "string", "number", "boolean").
+        """
+        fallback_value: Any
+        """
+        The default value used when a contact doesn't have this property set.
+        """
+
+    class UpdateParams(TypedDict):
+        """
+        UpdateParams is the class that wraps the parameters for updating a contact property.
+
+        Attributes:
+            id (str): The contact property ID
+            fallback_value (Any): The default value used when a contact doesn't have this property set
+        """
+
+        id: str
+        """
+        The contact property ID.
+        """
+        fallback_value: Any
+        """
+        The default value used when a contact doesn't have this property set.
+        """
+
+    @classmethod
+    def create(cls, params: CreateParams) -> CreateResponse:
+        """
+        Create a new contact property.
+        see more: https://resend.com/docs/api-reference/contact-properties/create-contact-property
+
+        Args:
+            params (CreateParams): The contact property creation parameters
+
+        Returns:
+            CreateResponse: The created contact property response
+        """
+        path = "/contact-properties"
+        resp = request.Request[ContactProperties.CreateResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def list(cls, params: Optional[ListParams] = None) -> ListResponse:
+        """
+        List all contact properties.
+        see more: https://resend.com/docs/api-reference/contact-properties/list-contact-properties
+
+        Args:
+            params (Optional[ListParams]): Optional pagination parameters
+                - limit: Number of contact properties to retrieve (max 100, min 1).
+                  If not provided, all contact properties will be returned without pagination.
+                - after: ID after which to retrieve more contact properties
+                - before: ID before which to retrieve more contact properties
+
+        Returns:
+            ListResponse: A list of contact property objects
+        """
+        base_path = "/contact-properties"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[ContactProperties.ListResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def get(cls, id: str) -> ContactProperty:
+        """
+        Get a contact property by ID.
+        see more: https://resend.com/docs/api-reference/contact-properties/get-contact-property
+
+        Args:
+            id (str): The contact property ID
+
+        Returns:
+            ContactProperty: The contact property object
+        """
+        path = f"/contact-properties/{id}"
+        resp = request.Request[ContactProperty](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, params: UpdateParams) -> UpdateResponse:
+        """
+        Update an existing contact property.
+        see more: https://resend.com/docs/api-reference/contact-properties/update-contact-property
+
+        Args:
+            params (UpdateParams): The contact property update parameters
+
+        Returns:
+            UpdateResponse: The updated contact property response
+        """
+        path = f"/contact-properties/{params['id']}"
+        resp = request.Request[ContactProperties.UpdateResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def remove(cls, id: str) -> RemoveResponse:
+        """
+        Remove a contact property by ID.
+        see more: https://resend.com/docs/api-reference/contact-properties/delete-contact-property
+
+        Args:
+            id (str): The contact property ID
+
+        Returns:
+            RemoveResponse: The removed contact property response object
+        """
+        path = f"/contact-properties/{id}"
+        resp = request.Request[ContactProperties.RemoveResponse](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp

--- a/resend/contact_properties/_contact_property.py
+++ b/resend/contact_properties/_contact_property.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from typing_extensions import TypedDict
+
+
+class ContactProperty(TypedDict):
+    """
+    ContactProperty represents a custom property definition for contacts.
+
+    Attributes:
+        id (str): The unique identifier for the contact property
+        key (str): The key name of the property
+        object (str): The object type, always "contact_property"
+        created_at (str): The ISO 8601 timestamp when the property was created
+        type (str): The data type of the property (e.g., "string", "number", "boolean")
+        fallback_value (Any): The default value used when a contact doesn't have this property set
+    """
+
+    id: str
+    """
+    The unique identifier for the contact property.
+    """
+    key: str
+    """
+    The key name of the property.
+    """
+    object: str
+    """
+    The object type, always "contact_property".
+    """
+    created_at: str
+    """
+    The ISO 8601 timestamp when the property was created.
+    """
+    type: str
+    """
+    The data type of the property (e.g., "string", "number", "boolean").
+    """
+    fallback_value: Any
+    """
+    The default value used when a contact doesn't have this property set.
+    """

--- a/resend/contact_properties/_contact_property.py
+++ b/resend/contact_properties/_contact_property.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Union
 
 from typing_extensions import TypedDict
 
@@ -12,8 +12,8 @@ class ContactProperty(TypedDict):
         key (str): The key name of the property
         object (str): The object type, always "contact_property"
         created_at (str): The ISO 8601 timestamp when the property was created
-        type (str): The data type of the property (e.g., "string", "number", "boolean")
-        fallback_value (Any): The default value used when a contact doesn't have this property set
+        type (str): The data type of the property (e.g., "string", "number")
+        fallback_value (Union[str, int, float, None]): The default value used when a contact doesn't have this property set
     """
 
     id: str
@@ -34,9 +34,10 @@ class ContactProperty(TypedDict):
     """
     type: str
     """
-    The data type of the property (e.g., "string", "number", "boolean").
+    The data type of the property (e.g., "string", "number").
     """
-    fallback_value: Any
+    fallback_value: Union[str, int, float, None]
     """
     The default value used when a contact doesn't have this property set.
+    Must match the type of the property (string or number).
     """

--- a/resend/contacts/_contact.py
+++ b/resend/contacts/_contact.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from typing_extensions import NotRequired, TypedDict
 
 
@@ -25,4 +27,8 @@ class Contact(TypedDict):
     unsubscribed: bool
     """
     The unsubscribed status of the contact.
+    """
+    properties: NotRequired[Dict[str, Any]]
+    """
+    Custom properties associated with the contact.
     """

--- a/resend/contacts/_contact.py
+++ b/resend/contacts/_contact.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from typing_extensions import NotRequired, TypedDict
 
 
@@ -27,8 +25,4 @@ class Contact(TypedDict):
     unsubscribed: bool
     """
     The unsubscribed status of the contact.
-    """
-    properties: NotRequired[Dict[str, Any]]
-    """
-    Custom properties associated with the contact.
     """

--- a/resend/contacts/_contact_topic.py
+++ b/resend/contacts/_contact_topic.py
@@ -1,0 +1,49 @@
+from typing_extensions import TypedDict
+
+
+class ContactTopic(TypedDict):
+    """
+    ContactTopic represents a topic subscription for a contact.
+
+    Attributes:
+        id (str): The unique identifier for the topic
+        name (str): The name of the topic
+        description (str): The description of the topic
+        subscription (str): The subscription status. Must be either "opt_in" or "opt_out"
+    """
+
+    id: str
+    """
+    The unique identifier for the topic.
+    """
+    name: str
+    """
+    The name of the topic.
+    """
+    description: str
+    """
+    The description of the topic.
+    """
+    subscription: str
+    """
+    The subscription status. Must be either "opt_in" or "opt_out".
+    """
+
+
+class TopicSubscriptionUpdate(TypedDict):
+    """
+    TopicSubscriptionUpdate represents an update to a topic subscription.
+
+    Attributes:
+        id (str): The topic ID
+        subscription (str): The subscription action. Must be either "opt_in" or "opt_out"
+    """
+
+    id: str
+    """
+    The topic ID.
+    """
+    subscription: str
+    """
+    The subscription action. Must be either "opt_in" or "opt_out".
+    """

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -133,10 +133,6 @@ class Contacts:
         """
         The unsubscribed status of the contact.
         """
-        properties: NotRequired[Dict[str, Any]]
-        """
-        Custom properties associated with the contact.
-        """
 
     class UpdateParams(TypedDict):
         audience_id: str
@@ -162,10 +158,6 @@ class Contacts:
         unsubscribed: NotRequired[bool]
         """
         The unsubscribed status of the contact.
-        """
-        properties: NotRequired[Dict[str, Any]]
-        """
-        Custom properties associated with the contact.
         """
 
     @classmethod

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -6,9 +6,11 @@ from resend import request
 from resend.pagination_helper import PaginationHelper
 
 from ._contact import Contact
+from ._topics import Topics
 
 
 class Contacts:
+    Topics = Topics
 
     class RemoveContactResponse(TypedDict):
         """
@@ -131,6 +133,10 @@ class Contacts:
         """
         The unsubscribed status of the contact.
         """
+        properties: NotRequired[Dict[str, Any]]
+        """
+        Custom properties associated with the contact.
+        """
 
     class UpdateParams(TypedDict):
         audience_id: str
@@ -156,6 +162,10 @@ class Contacts:
         unsubscribed: NotRequired[bool]
         """
         The unsubscribed status of the contact.
+        """
+        properties: NotRequired[Dict[str, Any]]
+        """
+        Custom properties associated with the contact.
         """
 
     @classmethod

--- a/resend/contacts/_topics.py
+++ b/resend/contacts/_topics.py
@@ -58,10 +58,6 @@ class _UpdateResponse(TypedDict):
     """
     The contact ID.
     """
-    object: str
-    """
-    The object type: "contact"
-    """
 
 
 class Topics:
@@ -105,7 +101,6 @@ class Topics:
 
         Attributes:
             id (str): The contact ID
-            object (str): The object type: "contact"
         """
 
     @classmethod

--- a/resend/contacts/_topics.py
+++ b/resend/contacts/_topics.py
@@ -1,0 +1,182 @@
+from typing import Any, Dict, List, Optional, Union, cast
+
+from typing_extensions import NotRequired, TypedDict
+
+from resend import request
+from resend.pagination_helper import PaginationHelper
+
+from ._contact_topic import ContactTopic, TopicSubscriptionUpdate
+
+
+class _ListParams(TypedDict):
+    limit: NotRequired[int]
+    """
+    Number of topics to retrieve. Maximum is 100, minimum is 1.
+    """
+    after: NotRequired[str]
+    """
+    The ID after which we'll retrieve more topics (for pagination).
+    """
+    before: NotRequired[str]
+    """
+    The ID before which we'll retrieve more topics (for pagination).
+    """
+
+
+class _ListResponse(TypedDict):
+    object: str
+    """
+    The object type: "list"
+    """
+    data: List[ContactTopic]
+    """
+    The list of contact topic objects.
+    """
+    has_more: bool
+    """
+    Whether there are more topics available for pagination.
+    """
+
+
+class _UpdateParams(TypedDict):
+    id: NotRequired[str]
+    """
+    The contact ID.
+    """
+    email: NotRequired[str]
+    """
+    The contact email.
+    """
+    topics: List[TopicSubscriptionUpdate]
+    """
+    List of topic subscription updates.
+    """
+
+
+class _UpdateResponse(TypedDict):
+    id: str
+    """
+    The contact ID.
+    """
+    object: str
+    """
+    The object type: "contact"
+    """
+
+
+class Topics:
+    """
+    Topics class that provides methods for managing contact topic subscriptions.
+    """
+
+    class ListParams(_ListParams):
+        """
+        ListParams is the class that wraps the parameters for the list method.
+
+        Attributes:
+            limit (NotRequired[int]): Number of topics to retrieve. Maximum is 100, minimum is 1.
+            after (NotRequired[str]): Return topics after this cursor for pagination.
+            before (NotRequired[str]): Return topics before this cursor for pagination.
+        """
+
+    class ListResponse(_ListResponse):
+        """
+        ListResponse is the type that wraps the response for listing contact topics.
+
+        Attributes:
+            object (str): The object type: "list"
+            data (List[ContactTopic]): The list of contact topic objects.
+            has_more (bool): Whether there are more topics available for pagination.
+        """
+
+    class UpdateParams(_UpdateParams):
+        """
+        UpdateParams is the class that wraps the parameters for updating contact topic subscriptions.
+
+        Attributes:
+            id (NotRequired[str]): The contact ID (either id or email must be provided)
+            email (NotRequired[str]): The contact email (either id or email must be provided)
+            topics (List[TopicSubscriptionUpdate]): List of topic subscription updates
+        """
+
+    class UpdateResponse(_UpdateResponse):
+        """
+        UpdateResponse is the type that wraps the response for updating contact topics.
+
+        Attributes:
+            id (str): The contact ID
+            object (str): The object type: "contact"
+        """
+
+    @classmethod
+    def list(
+        cls,
+        contact_id: Optional[str] = None,
+        email: Optional[str] = None,
+        params: Optional["Topics.ListParams"] = None,
+    ) -> "Topics.ListResponse":
+        """
+        List all topics for a contact.
+        see more: https://resend.com/docs/api-reference/contacts/list-contact-topics
+
+        Args:
+            contact_id (Optional[str]): The contact ID (either contact_id or email must be provided)
+            email (Optional[str]): The contact email (either contact_id or email must be provided)
+            params (Optional[ListParams]): Optional pagination parameters
+                - limit: Number of topics to retrieve (max 100, min 1).
+                  If not provided, all topics will be returned without pagination.
+                - after: ID after which to retrieve more topics
+                - before: ID before which to retrieve more topics
+
+        Returns:
+            ListResponse: A list of contact topic objects
+
+        Raises:
+            ValueError: If neither contact_id nor email is provided
+        """
+        contact = email if contact_id is None else contact_id
+        if contact is None:
+            raise ValueError("contact_id or email must be provided")
+
+        base_path = f"/contacts/{contact}/topics"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[_ListResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, params: UpdateParams) -> UpdateResponse:
+        """
+        Update topic subscriptions for a contact.
+        see more: https://resend.com/docs/api-reference/contacts/update-contact-topics
+
+        Args:
+            params (UpdateParams): The topic update parameters
+                - id: The contact ID (either id or email must be provided)
+                - email: The contact email (either id or email must be provided)
+                - topics: List of topic subscription updates
+
+        Returns:
+            UpdateResponse: The updated contact response
+
+        Raises:
+            ValueError: If neither id nor email is provided in params
+        """
+        if params.get("id") is None and params.get("email") is None:
+            raise ValueError("id or email must be provided")
+
+        contact = params.get("id") if params.get("id") is not None else params.get("email")
+        path = f"/contacts/{contact}/topics"
+
+        # Send the topics array directly as the request body (not wrapped in an object)
+        # The Request class accepts Union[Dict, List] as params
+        request_body: Union[Dict[str, Any], List[Dict[str, Any]]] = cast(
+            List[Dict[str, Any]], params["topics"]
+        )
+
+        resp = request.Request[_UpdateResponse](
+            path=path, params=request_body, verb="patch"
+        ).perform_with_content()
+        return resp

--- a/resend/contacts/_topics.py
+++ b/resend/contacts/_topics.py
@@ -167,7 +167,9 @@ class Topics:
         if params.get("id") is None and params.get("email") is None:
             raise ValueError("id or email must be provided")
 
-        contact = params.get("id") if params.get("id") is not None else params.get("email")
+        contact = (
+            params.get("id") if params.get("id") is not None else params.get("email")
+        )
         path = f"/contacts/{contact}/topics"
 
         # Send the topics array directly as the request body (not wrapped in an object)

--- a/tests/contact_properties_test.py
+++ b/tests/contact_properties_test.py
@@ -1,0 +1,187 @@
+import resend
+from resend.exceptions import NoContentError
+from tests.conftest import ResendBaseTest
+
+# flake8: noqa
+
+
+class TestResendContactProperties(ResendBaseTest):
+    def test_contact_properties_create(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "contact_property",
+                "id": "prop_123456",
+            }
+        )
+
+        params: resend.ContactProperties.CreateParams = {
+            "key": "age",
+            "type": "number",
+            "fallback_value": 0,
+        }
+        response: resend.ContactProperties.CreateResponse = (
+            resend.ContactProperties.create(params)
+        )
+        assert response["id"] == "prop_123456"
+        assert response["object"] == "contact_property"
+
+    def test_should_create_contact_property_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        params: resend.ContactProperties.CreateParams = {
+            "key": "age",
+            "type": "number",
+            "fallback_value": 0,
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.ContactProperties.create(params)
+
+    def test_contact_properties_list(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "prop_123456",
+                        "key": "age",
+                        "object": "contact_property",
+                        "created_at": "2023-10-06T23:47:56.678Z",
+                        "type": "number",
+                        "fallback_value": 0,
+                    }
+                ],
+            }
+        )
+
+        response: resend.ContactProperties.ListResponse = (
+            resend.ContactProperties.list()
+        )
+        assert response["object"] == "list"
+        assert response["has_more"] is False
+        assert response["data"][0]["id"] == "prop_123456"
+        assert response["data"][0]["key"] == "age"
+        assert response["data"][0]["type"] == "number"
+        assert response["data"][0]["fallback_value"] == 0
+
+    def test_should_list_contact_properties_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.ContactProperties.list()
+
+    def test_contact_properties_list_with_pagination(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": True,
+                "data": [
+                    {
+                        "id": "prop_1",
+                        "key": "age",
+                        "object": "contact_property",
+                        "created_at": "2023-10-06T23:47:56.678Z",
+                        "type": "number",
+                        "fallback_value": 0,
+                    },
+                    {
+                        "id": "prop_2",
+                        "key": "city",
+                        "object": "contact_property",
+                        "created_at": "2023-10-07T23:47:56.678Z",
+                        "type": "string",
+                        "fallback_value": "Unknown",
+                    },
+                ],
+            }
+        )
+
+        params: resend.ContactProperties.ListParams = {
+            "limit": 10,
+            "after": "prop_0",
+        }
+        response: resend.ContactProperties.ListResponse = (
+            resend.ContactProperties.list(params)
+        )
+        assert response["object"] == "list"
+        assert response["has_more"] is True
+        assert len(response["data"]) == 2
+        assert response["data"][0]["id"] == "prop_1"
+        assert response["data"][1]["id"] == "prop_2"
+
+    def test_contact_properties_get(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "prop_123456",
+                "key": "age",
+                "object": "contact_property",
+                "created_at": "2023-10-06T23:47:56.678Z",
+                "type": "number",
+                "fallback_value": 0,
+            }
+        )
+
+        property: resend.ContactProperty = resend.ContactProperties.get("prop_123456")
+        assert property["id"] == "prop_123456"
+        assert property["key"] == "age"
+        assert property["type"] == "number"
+        assert property["fallback_value"] == 0
+
+    def test_should_get_contact_property_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.ContactProperties.get("prop_123456")
+
+    def test_contact_properties_update(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "contact_property",
+                "id": "prop_123456",
+            }
+        )
+
+        params: resend.ContactProperties.UpdateParams = {
+            "id": "prop_123456",
+            "fallback_value": 18,
+        }
+        response: resend.ContactProperties.UpdateResponse = (
+            resend.ContactProperties.update(params)
+        )
+        assert response["id"] == "prop_123456"
+        assert response["object"] == "contact_property"
+
+    def test_should_update_contact_property_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        params: resend.ContactProperties.UpdateParams = {
+            "id": "prop_123456",
+            "fallback_value": 18,
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.ContactProperties.update(params)
+
+    def test_contact_properties_remove(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "contact_property",
+                "id": "prop_123456",
+                "deleted": True,
+            }
+        )
+
+        response: resend.ContactProperties.RemoveResponse = (
+            resend.ContactProperties.remove("prop_123456")
+        )
+        assert response["id"] == "prop_123456"
+        assert response["object"] == "contact_property"
+        assert response["deleted"] is True
+
+    def test_should_remove_contact_property_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.ContactProperties.remove("prop_123456")

--- a/tests/contact_properties_test.py
+++ b/tests/contact_properties_test.py
@@ -102,8 +102,8 @@ class TestResendContactProperties(ResendBaseTest):
             "limit": 10,
             "after": "prop_0",
         }
-        response: resend.ContactProperties.ListResponse = (
-            resend.ContactProperties.list(params)
+        response: resend.ContactProperties.ListResponse = resend.ContactProperties.list(
+            params
         )
         assert response["object"] == "list"
         assert response["has_more"] is True

--- a/tests/contact_topics_test.py
+++ b/tests/contact_topics_test.py
@@ -107,7 +107,6 @@ class TestResendContactTopics(ResendBaseTest):
         self.set_mock_json(
             {
                 "id": "cont_456",
-                "object": "contact",
             }
         )
 
@@ -120,13 +119,11 @@ class TestResendContactTopics(ResendBaseTest):
         }
         response: ContactsTopics.UpdateResponse = resend.Contacts.Topics.update(params)
         assert response["id"] == "cont_456"
-        assert response["object"] == "contact"
 
     def test_contact_topics_update_by_email(self) -> None:
         self.set_mock_json(
             {
                 "id": "cont_456",
-                "object": "contact",
             }
         )
 
@@ -138,7 +135,6 @@ class TestResendContactTopics(ResendBaseTest):
         }
         response: ContactsTopics.UpdateResponse = resend.Contacts.Topics.update(params)
         assert response["id"] == "cont_456"
-        assert response["object"] == "contact"
 
     def test_contact_topics_update_raises_when_no_contact_identifier(self) -> None:
         resend.api_key = "re_123"

--- a/tests/contact_topics_test.py
+++ b/tests/contact_topics_test.py
@@ -1,0 +1,169 @@
+import resend
+from resend.exceptions import NoContentError
+from tests.conftest import ResendBaseTest
+
+# flake8: noqa
+
+
+class TestResendContactTopics(ResendBaseTest):
+    def test_contact_topics_list_by_id(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "topic_123",
+                        "name": "Newsletter",
+                        "description": "Weekly newsletter",
+                        "subscription": "opt_in",
+                    }
+                ],
+            }
+        )
+
+        response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+            contact_id="cont_456"
+        )
+        assert response["object"] == "list"
+        assert response["has_more"] is False
+        assert response["data"][0]["id"] == "topic_123"
+        assert response["data"][0]["name"] == "Newsletter"
+        assert response["data"][0]["subscription"] == "opt_in"
+
+    def test_contact_topics_list_by_email(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "topic_123",
+                        "name": "Newsletter",
+                        "description": "Weekly newsletter",
+                        "subscription": "opt_in",
+                    }
+                ],
+            }
+        )
+
+        response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+            email="user@example.com"
+        )
+        assert response["object"] == "list"
+        assert response["has_more"] is False
+        assert response["data"][0]["id"] == "topic_123"
+
+    def test_contact_topics_list_with_pagination(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": True,
+                "data": [
+                    {
+                        "id": "topic_1",
+                        "name": "Newsletter",
+                        "description": "Weekly newsletter",
+                        "subscription": "opt_in",
+                    },
+                    {
+                        "id": "topic_2",
+                        "name": "Updates",
+                        "description": "Product updates",
+                        "subscription": "opt_out",
+                    },
+                ],
+            }
+        )
+
+        params: resend.Contacts.Topics.ListParams = {
+            "limit": 10,
+            "after": "topic_0",
+        }
+        response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+            contact_id="cont_456", params=params
+        )
+        assert response["object"] == "list"
+        assert response["has_more"] is True
+        assert len(response["data"]) == 2
+        assert response["data"][0]["id"] == "topic_1"
+        assert response["data"][1]["id"] == "topic_2"
+
+    def test_contact_topics_list_raises_when_no_contact_identifier(self) -> None:
+        resend.api_key = "re_123"
+
+        with self.assertRaises(ValueError) as context:
+            resend.Contacts.Topics.list()
+
+        self.assertEqual("contact_id or email must be provided", str(context.exception))
+
+    def test_should_list_contact_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.Topics.list(contact_id="cont_456")
+
+    def test_contact_topics_update_by_id(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "cont_456",
+                "object": "contact",
+            }
+        )
+
+        params: resend.Contacts.Topics.UpdateParams = {
+            "id": "cont_456",
+            "topics": [
+                {"id": "topic_1", "subscription": "opt_in"},
+                {"id": "topic_2", "subscription": "opt_out"},
+            ],
+        }
+        response: resend.Contacts.Topics.UpdateResponse = (
+            resend.Contacts.Topics.update(params)
+        )
+        assert response["id"] == "cont_456"
+        assert response["object"] == "contact"
+
+    def test_contact_topics_update_by_email(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "cont_456",
+                "object": "contact",
+            }
+        )
+
+        params: resend.Contacts.Topics.UpdateParams = {
+            "email": "user@example.com",
+            "topics": [
+                {"id": "topic_1", "subscription": "opt_in"},
+            ],
+        }
+        response: resend.Contacts.Topics.UpdateResponse = (
+            resend.Contacts.Topics.update(params)
+        )
+        assert response["id"] == "cont_456"
+        assert response["object"] == "contact"
+
+    def test_contact_topics_update_raises_when_no_contact_identifier(self) -> None:
+        resend.api_key = "re_123"
+
+        params: resend.Contacts.Topics.UpdateParams = {
+            "topics": [
+                {"id": "topic_1", "subscription": "opt_in"},
+            ],
+        }
+
+        with self.assertRaises(ValueError) as context:
+            resend.Contacts.Topics.update(params)
+
+        self.assertEqual("id or email must be provided", str(context.exception))
+
+    def test_should_update_contact_topics_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Contacts.Topics.UpdateParams = {
+            "id": "cont_456",
+            "topics": [
+                {"id": "topic_1", "subscription": "opt_in"},
+            ],
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Contacts.Topics.update(params)

--- a/tests/contact_topics_test.py
+++ b/tests/contact_topics_test.py
@@ -1,4 +1,5 @@
 import resend
+from resend import ContactsTopics
 from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
@@ -22,7 +23,7 @@ class TestResendContactTopics(ResendBaseTest):
             }
         )
 
-        response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+        response: ContactsTopics.ListResponse = resend.Contacts.Topics.list(
             contact_id="cont_456"
         )
         assert response["object"] == "list"
@@ -47,7 +48,7 @@ class TestResendContactTopics(ResendBaseTest):
             }
         )
 
-        response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+        response: ContactsTopics.ListResponse = resend.Contacts.Topics.list(
             email="user@example.com"
         )
         assert response["object"] == "list"
@@ -76,11 +77,11 @@ class TestResendContactTopics(ResendBaseTest):
             }
         )
 
-        params: resend.Contacts.Topics.ListParams = {
+        params: ContactsTopics.ListParams = {
             "limit": 10,
             "after": "topic_0",
         }
-        response: resend.Contacts.Topics.ListResponse = resend.Contacts.Topics.list(
+        response: ContactsTopics.ListResponse = resend.Contacts.Topics.list(
             contact_id="cont_456", params=params
         )
         assert response["object"] == "list"
@@ -110,16 +111,14 @@ class TestResendContactTopics(ResendBaseTest):
             }
         )
 
-        params: resend.Contacts.Topics.UpdateParams = {
+        params: ContactsTopics.UpdateParams = {
             "id": "cont_456",
             "topics": [
                 {"id": "topic_1", "subscription": "opt_in"},
                 {"id": "topic_2", "subscription": "opt_out"},
             ],
         }
-        response: resend.Contacts.Topics.UpdateResponse = (
-            resend.Contacts.Topics.update(params)
-        )
+        response: ContactsTopics.UpdateResponse = resend.Contacts.Topics.update(params)
         assert response["id"] == "cont_456"
         assert response["object"] == "contact"
 
@@ -131,22 +130,20 @@ class TestResendContactTopics(ResendBaseTest):
             }
         )
 
-        params: resend.Contacts.Topics.UpdateParams = {
+        params: ContactsTopics.UpdateParams = {
             "email": "user@example.com",
             "topics": [
                 {"id": "topic_1", "subscription": "opt_in"},
             ],
         }
-        response: resend.Contacts.Topics.UpdateResponse = (
-            resend.Contacts.Topics.update(params)
-        )
+        response: ContactsTopics.UpdateResponse = resend.Contacts.Topics.update(params)
         assert response["id"] == "cont_456"
         assert response["object"] == "contact"
 
     def test_contact_topics_update_raises_when_no_contact_identifier(self) -> None:
         resend.api_key = "re_123"
 
-        params: resend.Contacts.Topics.UpdateParams = {
+        params: ContactsTopics.UpdateParams = {
             "topics": [
                 {"id": "topic_1", "subscription": "opt_in"},
             ],
@@ -159,7 +156,7 @@ class TestResendContactTopics(ResendBaseTest):
 
     def test_should_update_contact_topics_raise_exception_when_no_content(self) -> None:
         self.set_mock_json(None)
-        params: resend.Contacts.Topics.UpdateParams = {
+        params: ContactsTopics.UpdateParams = {
             "id": "cont_456",
             "topics": [
                 {"id": "topic_1", "subscription": "opt_in"},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds ContactProperties API (create, list, get, update, remove) and contact topics list/update for contacts. Updates Contacts to support custom properties and exposes new types in the public API.

- **New Features**
  - Contact properties: create/list/get/update/remove with pagination; new ContactProperty type; exported via resend.ContactProperties and resend.ContactProperty.
  - Contact topics: list and update subscriptions by contact ID or email; pagination supported; exported via resend.Contacts.Topics and ContactsTopics types.
  - Contacts now accept and return optional custom properties in Contact, CreateParams, and UpdateParams.
  - Examples and tests added for both features.

<!-- End of auto-generated description by cubic. -->

