### PR TITLE
feat: add rate limit error class

### DIFF
--- a/resend/contacts/_topics.py
+++ b/resend/contacts/_topics.py
@@ -112,7 +112,7 @@ class Topics:
     ) -> "Topics.ListResponse":
         """
         List all topics for a contact.
-        see more: https://resend.com/docs/api-reference/contacts/list-contact-topics
+        see more: https://resend.com/docs/api-reference/contacts/get-contact-topics
 
         Args:
             contact_id (Optional[str]): The contact ID (either contact_id or email must be provided)

--- a/resend/exceptions.py
+++ b/resend/exceptions.py
@@ -169,7 +169,8 @@ class RateLimitError(ResendError):
         error_type: str,
         code: Union[str, int],
     ):
-        suggested_action = """Reduce your request rate or wait before retrying. Check the response headers for rate limit information."""
+        suggested_action = """Reduce your request rate or wait before retrying. """
+        suggested_action += """Check the response headers for rate limit information."""
 
         ResendError.__init__(
             self,

--- a/resend/exceptions.py
+++ b/resend/exceptions.py
@@ -160,6 +160,26 @@ class ApplicationError(ResendError):
         )
 
 
+class RateLimitError(ResendError):
+    """see https://resend.com/docs/api-reference/errors"""
+
+    def __init__(
+        self,
+        message: str,
+        error_type: str,
+        code: Union[str, int],
+    ):
+        suggested_action = """Reduce your request rate or wait before retrying. Check the response headers for rate limit information."""
+
+        ResendError.__init__(
+            self,
+            code=code or "429",
+            message=message,
+            suggested_action=suggested_action,
+            error_type=error_type,
+        )
+
+
 # Dict with error code -> error type mapping
 ERRORS: Dict[str, Dict[str, Any]] = {
     "400": {"validation_error": ValidationError},
@@ -169,6 +189,11 @@ ERRORS: Dict[str, Dict[str, Any]] = {
     },
     "401": {"missing_api_key": MissingApiKeyError},
     "403": {"invalid_api_key": InvalidApiKeyError},
+    "429": {
+        "rate_limit_exceeded": RateLimitError,
+        "daily_quota_exceeded": RateLimitError,
+        "monthly_quota_exceeded": RateLimitError,
+    },
     "500": {"application_error": ApplicationError},
 }
 
@@ -193,6 +218,8 @@ def raise_for_code_and_type(
         MissingApiKeyError: If the error type is missing_api_key
             or
         InvalidApiKeyError: If the error type is invalid_api_key
+            or
+        RateLimitError: If the error type is rate_limit_exceeded, daily_quota_exceeded, or monthly_quota_exceeded
             or
         ApplicationError: If the error type is application_error
             or

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.19.0"
+__version__ = "2.20.0"
 
 
 def get_version() -> str:

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from resend.exceptions import (ApplicationError, MissingApiKeyError,
-                               ResendError, ValidationError,
+                               RateLimitError, ResendError, ValidationError,
                                raise_for_code_and_type)
 
 
@@ -32,3 +32,24 @@ class TestResendError(unittest.TestCase):
         with pytest.raises(ApplicationError) as e:
             raise_for_code_and_type(500, "application_error", "err")
         assert e.type is ApplicationError
+
+    def test_rate_limit_exceeded_error(self) -> None:
+        with pytest.raises(RateLimitError) as e:
+            raise_for_code_and_type(429, "rate_limit_exceeded", "Rate limit exceeded")
+        assert e.type is RateLimitError
+        assert e.value.code == 429
+        assert e.value.error_type == "rate_limit_exceeded"
+
+    def test_daily_quota_exceeded_error(self) -> None:
+        with pytest.raises(RateLimitError) as e:
+            raise_for_code_and_type(429, "daily_quota_exceeded", "Daily quota exceeded")
+        assert e.type is RateLimitError
+        assert e.value.code == 429
+        assert e.value.error_type == "daily_quota_exceeded"
+
+    def test_monthly_quota_exceeded_error(self) -> None:
+        with pytest.raises(RateLimitError) as e:
+            raise_for_code_and_type(429, "monthly_quota_exceeded", "Monthly quota exceeded")
+        assert e.type is RateLimitError
+        assert e.value.code == 429
+        assert e.value.error_type == "monthly_quota_exceeded"


### PR DESCRIPTION
closes https://github.com/resend/resend-python/issues/33


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add RateLimitError for 429 responses to make rate limit and quota errors clear and actionable. Also bumps the package to v2.20.0 and updates the contact topics docs link.

- **New Features**
  - Added RateLimitError and mapped 429 errors: rate_limit_exceeded, daily_quota_exceeded, monthly_quota_exceeded.
  - raise_for_code_and_type now raises RateLimitError for these cases.
  - Added tests covering all 429 error types.

- **Bug Fixes**
  - Corrected contacts topics docs URL in _topics.py.

<sup>Written for commit ef834d4523aa9da4faed9de94374b0693a162378. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



