### PR TITLE
feat: support for send/scheduled_at in broadcasts

### DIFF
--- a/resend/broadcasts/_broadcasts.py
+++ b/resend/broadcasts/_broadcasts.py
@@ -39,6 +39,8 @@ class Broadcasts:
             html (NotRequired[str]): The HTML version of the message.
             text (NotRequired[str]): The text version of the message.
             name (NotRequired[str]): The friendly name of the broadcast. Only used for internal reference.
+            send (NotRequired[bool]): When true, the broadcast will be sent immediately after creation.
+            scheduled_at (NotRequired[str]): Schedule the broadcast to be sent later. Only valid when send is true.
         """
 
         segment_id: NotRequired[str]
@@ -71,6 +73,17 @@ class Broadcasts:
         name: NotRequired[str]
         """
         The friendly name of the broadcast. Only used for internal reference.
+        """
+        send: NotRequired[bool]
+        """
+        When set to true, the broadcast will be sent immediately after creation.
+        If false or not provided, the broadcast will be created as a draft.
+        """
+        scheduled_at: NotRequired[str]
+        """
+        Schedule the broadcast to be sent later.
+        Only valid when send is set to true.
+        The date should be in natural language (e.g.: in 1 min) or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
         """
 
     class UpdateParams(_UpdateParamsFrom):

--- a/tests/broadcasts_test.py
+++ b/tests/broadcasts_test.py
@@ -74,6 +74,33 @@ class TestResendBroadcasts(ResendBaseTest):
         broadcast = resend.Broadcasts.send(params)
         assert broadcast["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e791"
 
+    def test_broadcasts_create_and_send(self) -> None:
+        self.set_mock_json({"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"})
+
+        params: resend.Broadcasts.CreateParams = {
+            "audience_id": "78b8d3bc-a55a-45a3-aee6-6ec0a5e13d7e",
+            "from": "hi@example.com",
+            "subject": "Hello, world!",
+            "name": "Python SDK Broadcast",
+            "send": True,
+        }
+        broadcast: resend.Broadcasts.CreateResponse = resend.Broadcasts.create(params)
+        assert broadcast["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+
+    def test_broadcasts_create_and_schedule(self) -> None:
+        self.set_mock_json({"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"})
+
+        params: resend.Broadcasts.CreateParams = {
+            "audience_id": "78b8d3bc-a55a-45a3-aee6-6ec0a5e13d7e",
+            "from": "hi@example.com",
+            "subject": "Hello, world!",
+            "name": "Python SDK Broadcast",
+            "send": True,
+            "scheduled_at": "2024-12-21T19:32:22.980Z",
+        }
+        broadcast: resend.Broadcasts.CreateResponse = resend.Broadcasts.create(params)
+        assert broadcast["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+
     def test_broadcasts_remove(self) -> None:
         self.set_mock_json(
             {

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -49,7 +49,9 @@ class TestResendError(unittest.TestCase):
 
     def test_monthly_quota_exceeded_error(self) -> None:
         with pytest.raises(RateLimitError) as e:
-            raise_for_code_and_type(429, "monthly_quota_exceeded", "Monthly quota exceeded")
+            raise_for_code_and_type(
+                429, "monthly_quota_exceeded", "Monthly quota exceeded"
+            )
         assert e.type is RateLimitError
         assert e.value.code == 429
         assert e.value.error_type == "monthly_quota_exceeded"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for send and scheduled_at in Broadcasts.create so you can send immediately or schedule a broadcast at creation. Default behavior remains draft when send is false or omitted.

- **New Features**
  - CreateParams.send (bool): send immediately after creation; omit/false keeps as draft.
  - CreateParams.scheduled_at (str): schedule send when send is true; accepts natural language or ISO 8601.

<sup>Written for commit 1ff75b0d1966726b51c2219f43e103046584f913. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

