### PR TITLE
feat: add support data method on responses

### DIFF
--- a/resend/request.py
+++ b/resend/request.py
@@ -6,6 +6,7 @@ from typing_extensions import Literal, TypeVar
 import resend
 from resend.exceptions import (NoContentError, ResendError,
                                raise_for_code_and_type)
+from resend.response import ResponseDict
 from resend.version import get_version
 
 RequestVerb = Literal["get", "post", "put", "patch", "delete"]
@@ -38,6 +39,8 @@ class Request(Generic[T]):
                 error_type=data.get("name", "InternalServerError"),
             )
 
+        if isinstance(data, dict):
+            data = ResponseDict(data)
         return cast(T, data)
 
     def perform_with_content(self) -> T:

--- a/resend/response.py
+++ b/resend/response.py
@@ -1,0 +1,15 @@
+class ResponseDict(dict):
+    """Dict subclass that supports attribute-style access.
+
+    This allows SDK responses to be accessed using either dict syntax
+    (response['data']) or attribute syntax (response.data), providing
+    consistency with other Resend SDKs (e.g., Node.js).
+    """
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )

--- a/resend/response.py
+++ b/resend/response.py
@@ -1,7 +1,7 @@
-from typing import Any
+from typing import Any, Dict
 
 
-class ResponseDict(dict[str, Any]):
+class ResponseDict(Dict[str, Any]):
     """Dict subclass that supports attribute-style access.
 
     This allows SDK responses to be accessed using either dict syntax

--- a/resend/response.py
+++ b/resend/response.py
@@ -1,4 +1,7 @@
-class ResponseDict(dict):
+from typing import Any
+
+
+class ResponseDict(dict[str, Any]):
     """Dict subclass that supports attribute-style access.
 
     This allows SDK responses to be accessed using either dict syntax
@@ -6,7 +9,7 @@ class ResponseDict(dict):
     consistency with other Resend SDKs (e.g., Node.js).
     """
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         try:
             return self[name]
         except KeyError:

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.21.0"
+__version__ = "2.22.0"
 
 
 def get_version() -> str:

--- a/tests/response_test.py
+++ b/tests/response_test.py
@@ -1,0 +1,89 @@
+import resend
+from tests.conftest import ResendBaseTest
+
+# flake8: noqa
+
+
+class TestResponseDict(ResendBaseTest):
+
+    def test_list_response_supports_dict_access(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "att-1",
+                        "filename": "avatar.png",
+                        "content_type": "image/png",
+                        "content_disposition": "inline",
+                        "size": 1024,
+                    },
+                ],
+            }
+        )
+
+        attachments = resend.Emails.Receiving.Attachments.list(
+            email_id="test-email-id"
+        )
+        assert attachments["object"] == "list"
+        assert attachments["has_more"] is False
+        assert len(attachments["data"]) == 1
+        assert attachments["data"][0]["id"] == "att-1"
+
+    def test_list_response_supports_attribute_access(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "att-1",
+                        "filename": "avatar.png",
+                        "content_type": "image/png",
+                        "content_disposition": "inline",
+                        "size": 1024,
+                    },
+                ],
+            }
+        )
+
+        attachments = resend.Emails.Receiving.Attachments.list(
+            email_id="test-email-id"
+        )
+        assert attachments.object == "list"  # type: ignore[attr-defined]
+        assert attachments.has_more is False  # type: ignore[attr-defined]
+        assert len(attachments.data) == 1  # type: ignore[attr-defined]
+        assert attachments.data[0]["id"] == "att-1"  # type: ignore[attr-defined]
+
+    def test_attribute_access_raises_for_missing_key(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [],
+            }
+        )
+
+        attachments = resend.Emails.Receiving.Attachments.list(
+            email_id="test-email-id"
+        )
+        with self.assertRaises(AttributeError):
+            _ = attachments.nonexistent  # type: ignore[attr-defined]
+
+    def test_single_response_supports_attribute_access(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            }
+        )
+
+        params: resend.Emails.SendParams = {
+            "from": "from@email.io",
+            "to": ["to@email.io"],
+            "subject": "subject",
+            "html": "<p>Hello</p>",
+        }
+        email = resend.Emails.send(params)
+        assert email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert email.id == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"  # type: ignore[attr-defined]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add attribute-style access to API responses via ResponseDict, so you can use response.data, response.id, etc., while keeping dict access. Bumps SDK version to 2.22.0.

- **New Features**
  - Wrap dict responses in ResponseDict to support both response['data'] and response.data; missing attributes raise AttributeError.

<sup>Written for commit 65b9d523effaeec619f74b2d74bb84eecbfce9be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

