### PR TITLE
chore: bump version to 2.28.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.27.0"
+__version__ = "2.28.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `__version__` to 2.28.0 to prepare the 2.28.0 release.

<sup>Written for commit 6ee05f86535ecd783acb2d3e9e926e850423dd01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

