### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/resend/domains/_record.py
+++ b/resend/domains/_record.py
@@ -4,7 +4,7 @@ from typing_extensions import NotRequired, TypedDict
 class Record(TypedDict):
     record: str
     """
-    The domain record type, ie: SPF, DKIM, Inbound, Tracking.
+    The domain record type, ie: SPF, DKIM, Inbound, Tracking, TrackingCAA.
     """
     name: str
     """

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.28.0"
+__version__ = "2.28.1"
 
 
 def get_version() -> str:

--- a/tests/domains_async_test.py
+++ b/tests/domains_async_test.py
@@ -173,6 +173,14 @@ class TestResendDomainsAsync(AsyncResendBaseTest):
                         "ttl": "Auto",
                         "status": "not_started",
                     },
+                    {
+                        "record": "TrackingCAA",
+                        "name": "",
+                        "value": '0 issue "amazon.com"',
+                        "type": "CAA",
+                        "ttl": "Auto",
+                        "status": "not_started",
+                    },
                 ],
                 "region": "us-east-1",
             }
@@ -195,6 +203,13 @@ class TestResendDomainsAsync(AsyncResendBaseTest):
         assert tracking_record["name"] == "links.example.com"
         assert tracking_record["value"] == "links1.resend-dns.com"
         assert tracking_record["type"] == "CNAME"
+        tracking_caa_record = next(
+            (r for r in (domain["records"] or []) if r["record"] == "TrackingCAA"),
+            None,
+        )
+        assert tracking_caa_record is not None
+        assert tracking_caa_record["type"] == "CAA"
+        assert tracking_caa_record["value"] == '0 issue "amazon.com"'
 
     async def test_domains_get_async_with_tracking_fields(self) -> None:
         self.set_mock_json(
@@ -216,7 +231,15 @@ class TestResendDomainsAsync(AsyncResendBaseTest):
                         "type": "CNAME",
                         "ttl": "Auto",
                         "status": "verified",
-                    }
+                    },
+                    {
+                        "record": "TrackingCAA",
+                        "name": "",
+                        "value": '0 issue "amazon.com"',
+                        "type": "CAA",
+                        "ttl": "Auto",
+                        "status": "verified",
+                    },
                 ],
             }
         )
@@ -228,6 +251,12 @@ class TestResendDomainsAsync(AsyncResendBaseTest):
         assert domain["open_tracking"] is True
         assert domain["click_tracking"] is True
         assert domain["tracking_subdomain"] == "links"
+        tracking_caa_record = next(
+            (r for r in (domain["records"] or []) if r["record"] == "TrackingCAA"),
+            None,
+        )
+        assert tracking_caa_record is not None
+        assert tracking_caa_record["type"] == "CAA"
 
     async def test_domains_update_async(self) -> None:
         self.set_mock_json(

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -207,6 +207,14 @@ class TestResendDomains(ResendBaseTest):
                         "ttl": "Auto",
                         "status": "not_started",
                     },
+                    {
+                        "record": "TrackingCAA",
+                        "name": "",
+                        "value": '0 issue "amazon.com"',
+                        "type": "CAA",
+                        "ttl": "Auto",
+                        "status": "not_started",
+                    },
                 ],
                 "region": "us-east-1",
             }
@@ -231,6 +239,13 @@ class TestResendDomains(ResendBaseTest):
         assert tracking_record["name"] == "links.example.com"
         assert tracking_record["value"] == "links1.resend-dns.com"
         assert tracking_record["type"] == "CNAME"
+        tracking_caa_record = next(
+            (r for r in (domain["records"] or []) if r["record"] == "TrackingCAA"),
+            None,
+        )
+        assert tracking_caa_record is not None
+        assert tracking_caa_record["type"] == "CAA"
+        assert tracking_caa_record["value"] == '0 issue "amazon.com"'
 
     def test_domains_get_with_tracking_fields(self) -> None:
         self.set_mock_json(
@@ -252,7 +267,15 @@ class TestResendDomains(ResendBaseTest):
                         "type": "CNAME",
                         "ttl": "Auto",
                         "status": "verified",
-                    }
+                    },
+                    {
+                        "record": "TrackingCAA",
+                        "name": "",
+                        "value": '0 issue "amazon.com"',
+                        "type": "CAA",
+                        "ttl": "Auto",
+                        "status": "verified",
+                    },
                 ],
             }
         )
@@ -264,6 +287,12 @@ class TestResendDomains(ResendBaseTest):
         assert domain["open_tracking"] is True
         assert domain["click_tracking"] is True
         assert domain["tracking_subdomain"] == "links"
+        tracking_caa_record = next(
+            (r for r in (domain["records"] or []) if r["record"] == "TrackingCAA"),
+            None,
+        )
+        assert tracking_caa_record is not None
+        assert tracking_caa_record["type"] == "CAA"
 
     def test_domains_update(self) -> None:
         self.set_mock_json(


### PR DESCRIPTION
## Summary

The Domains API now returns an extra DNS record on `POST /domains` and `GET /domains/:id` when a tracking subdomain is configured **and** the customer's root domain has CAA records that would prevent AWS from issuing a certificate for the tracking subdomain:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

The `Record` TypedDict already accepts arbitrary string values for `record` and `type`, so no source change is required beyond a docstring update — the record deserializes today. This PR extends the test fixtures (sync + async) so the new record is exercised, and updates the docstring to list `TrackingCAA` as a known example value.

## Test plan

- [x] `pytest tests/domains_test.py tests/domains_async_test.py` — 32 passed (including the new `TrackingCAA` assertions in `test_domains_create_with_tracking_subdomain`, `test_domains_get_with_tracking_fields`, and their async equivalents)

Tracking: [Linear ENG-4843](https://linear.app/resend/issue/ENG-4843/python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TrackingCAA` DNS record support in domain responses when a tracking subdomain is set and root-domain CAA would block AWS from issuing the tracking certificate. Aligns with Linear ENG-4843.

- **New Features**
  - Updated `Record` docstring to include `TrackingCAA`.
  - Extended sync and async tests to cover the new `CAA` record (`value: 0 issue "amazon.com"`) and ensure it deserializes correctly.

- **Dependencies**
  - Bumped `resend` version to 2.28.1.

<sup>Written for commit 86d23b380be3353df4fd876fc43828aeb29518a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

