### PR TITLE
feat(domains): add click_tracking and open_tracking to CreateParams

### DIFF
--- a/resend/domains/_domains.py
+++ b/resend/domains/_domains.py
@@ -162,6 +162,14 @@ class Domains:
         """
         The custom subdomain used for click and open tracking links (e.g., "links").
         """
+        click_tracking: NotRequired[bool]
+        """
+        Track clicks within the body of each HTML email.
+        """
+        open_tracking: NotRequired[bool]
+        """
+        Track the open rate of each email.
+        """
 
     @classmethod
     def create(cls, params: CreateParams) -> CreateDomainResponse:

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.28.1"
+__version__ = "2.29.0"
 
 
 def get_version() -> str:

--- a/tests/domains_async_test.py
+++ b/tests/domains_async_test.py
@@ -190,6 +190,8 @@ class TestResendDomainsAsync(AsyncResendBaseTest):
             "name": "example.com",
             "region": "us-east-1",
             "tracking_subdomain": "links",
+            "click_tracking": True,
+            "open_tracking": True,
         }
         domain = await resend.Domains.create_async(params=create_params)
         assert domain["id"] == "4dd369bc-aa82-4ff3-97de-514ae3000ee0"

--- a/tests/domains_test.py
+++ b/tests/domains_test.py
@@ -224,6 +224,8 @@ class TestResendDomains(ResendBaseTest):
             "name": "example.com",
             "region": "us-east-1",
             "tracking_subdomain": "links",
+            "click_tracking": True,
+            "open_tracking": True,
         }
         domain: resend.Domains.CreateDomainResponse = resend.Domains.create(
             params=create_params


### PR DESCRIPTION
## Summary
- Add `click_tracking` and `open_tracking` optional fields to `Domains.CreateParams`, allowing these to be set at domain creation time instead of requiring a separate update call
- Update sync and async tests to exercise the new create params

## Test plan
- [x] Verified Python syntax parses correctly
- [ ] Run `python -m pytest tests/domains_test.py tests/domains_async_test.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `click_tracking` and `open_tracking` to `Domains.CreateParams` to enable click and open tracking at domain creation, avoiding a follow-up update. Updated sync and async tests to cover these params; bumped package version to `2.29.0`.

<sup>Written for commit 3e415c75bcc8ff9e848620e7c1f6516cc24fdf63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

