### PR TITLE
chore: bump version to 2.30.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.29.0"
+__version__ = "2.30.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bumps version from `2.29.0` to `2.30.0`.

## Changes since v2.29.0

- feat(contacts): add `segment_id` support to `Contacts.list` and `Contacts.list_async` (#202)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the library version from 2.29.0 to 2.30.0. This release publishes `segment_id` support in `Contacts.list` and `Contacts.list_async`.

<sup>Written for commit abe3e45e19e5c89875b1c77870cb93916a7b0eac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

