### PR TITLE
fix(emails): make filename and content_disposition nullable in EmailAttachment types

### DIFF
--- a/resend/emails/_received_email.py
+++ b/resend/emails/_received_email.py
@@ -11,9 +11,9 @@ class EmailAttachment(TypedDict):
 
     Attributes:
         id (str): The attachment ID.
-        filename (str): The filename of the attachment.
+        filename (Optional[str]): The filename of the attachment.
         content_type (str): The content type of the attachment.
-        content_disposition (str): The content disposition of the attachment.
+        content_disposition (Optional[str]): The content disposition of the attachment.
         content_id (NotRequired[str]): The content ID for inline attachments.
         size (NotRequired[int]): The size of the attachment in bytes.
     """
@@ -22,7 +22,7 @@ class EmailAttachment(TypedDict):
     """
     The attachment ID.
     """
-    filename: str
+    filename: Optional[str]
     """
     The filename of the attachment.
     """
@@ -30,7 +30,7 @@ class EmailAttachment(TypedDict):
     """
     The content type of the attachment.
     """
-    content_disposition: str
+    content_disposition: Optional[str]
     """
     The content disposition of the attachment.
     """
@@ -51,9 +51,9 @@ class EmailAttachmentDetails(TypedDict):
     Attributes:
         object (str): The object type.
         id (str): The attachment ID.
-        filename (str): The filename of the attachment.
+        filename (Optional[str]): The filename of the attachment.
         content_type (str): The content type of the attachment.
-        content_disposition (str): The content disposition of the attachment.
+        content_disposition (Optional[str]): The content disposition of the attachment.
         content_id (NotRequired[str]): The content ID for inline attachments.
         download_url (str): The URL to download the attachment.
         expires_at (str): When the download URL expires.
@@ -67,7 +67,7 @@ class EmailAttachmentDetails(TypedDict):
     """
     The attachment ID.
     """
-    filename: str
+    filename: Optional[str]
     """
     The filename of the attachment.
     """
@@ -75,7 +75,7 @@ class EmailAttachmentDetails(TypedDict):
     """
     The content type of the attachment.
     """
-    content_disposition: str
+    content_disposition: Optional[str]
     """
     The content disposition of the attachment.
     """


### PR DESCRIPTION
open api spec updated here: https://github.com/resend/resend-openapi/pull/64

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `filename` and `content_disposition` nullable in received email attachment types to match API responses and avoid type errors. Applies to `EmailAttachment` and `EmailAttachmentDetails` in `resend/emails/_received_email.py` and addresses DEV-609.

- **Bug Fixes**
  - Changed `filename` and `content_disposition` from `str` to `Optional[str]` in `EmailAttachment` and `EmailAttachmentDetails`.
  - Aligns Python types with cases where these fields are null in real emails.

<sup>Written for commit e4e9b278020a5afe75101e51946ee7412eb39dc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

