### PR TITLE
chore: bump version to 2.30.1

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.30.0"
+__version__ = "2.30.1"
 
 
 def get_version() -> str:


### PR DESCRIPTION
## Summary

- Bumps version from `2.30.0` to `2.30.1`

## Changes since v2.30.0

- `fix(emails)`: make `filename` and `content_disposition` nullable in `EmailAttachment` types (#205)
- `chore`: GH Actions hardening (#204)
- `chore(deps)`: update Python Docker tag to v3.14.5 (#196)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `resend` 2.30.1. Fixes `EmailAttachment` types by making `filename` and `content_disposition` nullable; also hardens GitHub Actions and updates the Python Docker tag to v3.14.5.

<sup>Written for commit b8aa7c842373d16afac117e033f1c69a78788430. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

