### PR TITLE
chore: bump public-shared-workflows hash

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@3bbf3351f179ea225614e362c90a47ed2e4d07a2
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@235fbe2ab5eff9198d18f0b4608eb0b8ddc52ede
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Updates `sync_prs_to_linear` action SHA from `3bbf335` to `235fbe2`, picking up the org membership check to avoid syncing private org members to Linear.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `resend/public-shared-workflows/.github/actions/sync_prs_to_linear` from `3bbf335` to `235fbe2` to include the org membership check, preventing syncing private org members to Linear.

<sup>Written for commit cc8d6f62ae93bbeed6db93e472ab0bd5af588092. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-python/pull/210?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

