### PR TITLE
Fix installing from sdist (setup.py imports the package, pulling typing_extensions at build time)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python
 
+import os
+import re
+
 from setuptools import find_packages, setup
 
-from resend.version import get_version
+# Read the version without importing the package (its deps may not be installed)
+with open("resend/version.py", encoding="utf8") as f:
+    version = re.search(r'__version__ = "([^"]+)"', f.read()).group(1)
 
-install_requires = open("requirements.txt").readlines()
+if os.path.exists("requirements.txt"):
+    install_requires = open("requirements.txt").readlines()
+else:
+    install_requires = ["requests>=2.31.0", "typing_extensions>=4.4.0"]
 
 setup(
     name="resend",
-    version=get_version(),
+    version=version,
     description="Resend Python SDK",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Installing resend from source currently fails in any isolated build:

```
$ docker run --rm python:3.12 pip install --no-binary :all: resend
...
ModuleNotFoundError: No module named 'typing_extensions'
```

setup.py imports the package to get `__version__`, which pulls typing_extensions into the build environment, and reads a requirements file not shipped in the sdist. This change reads the version statically (stdlib `re` over resend/version.py) and guards the file read with the pinned fallback.

Verified: with this change, `python -m build` (sdist → wheel built from that sdist) succeeds in a clean python:3.12 container; without it, it fails. Found while build-checking popular PyPI packages for source-install breakage ([wheelproof](https://github.com/sethc555/wheelproof)).

Also verified: a wheel built from the patched 2.30.1 sdist is payload-identical to the published 2.30.1 wheel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sdist installs for `resend` by avoiding build-time package import and guarding a missing `requirements.txt`. Isolated source builds now succeed without needing `typing_extensions` preinstalled.

- **Bug Fixes**
  - Parse version from `resend/version.py` using stdlib `re` instead of importing the package.
  - Read `requirements.txt` only if present; otherwise use `["requests>=2.31.0", "typing_extensions>=4.4.0"]`.
  - Verified `python -m build` sdist→wheel works in a clean Python 3.12 container; wheel from patched 2.30.1 sdist matches the published wheel payload.

<sup>Written for commit 6a5ef9d7e158e99428db052d662642326da1b0e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

