### PR TITLE
feat: missing query parameter for GET on a received email

### DIFF
--- a/resend/emails/_receiving.py
+++ b/resend/emails/_receiving.py
@@ -30,6 +30,7 @@ class _ListParams(TypedDict):
     Return emails before this cursor for pagination.
     """
 
+
 class _GetParams(TypedDict):
     html_format: NotRequired[Literal["data_uri", "cid"]]
     """
@@ -245,9 +246,7 @@ class Receiving:
         """
 
     @classmethod
-    def get(
-        cls, email_id: str, params: Optional[GetParams] = None
-    ) -> ReceivedEmail:
+    def get(cls, email_id: str, params: Optional[GetParams] = None) -> ReceivedEmail:
         """
         Retrieve a single received email.
         see more: https://resend.com/docs/api-reference/emails/retrieve-received-email

--- a/resend/emails/_receiving.py
+++ b/resend/emails/_receiving.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, cast
 
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import Literal, NotRequired, TypedDict
 
 from resend import request
 from resend._base_response import BaseResponse
@@ -28,6 +28,15 @@ class _ListParams(TypedDict):
     before: NotRequired[str]
     """
     Return emails before this cursor for pagination.
+    """
+
+class _GetParams(TypedDict):
+    html_format: NotRequired[Literal["data_uri", "cid"]]
+    """
+    Controls how inline images are returned inside ``html``. By default (or when
+    set to ``"data_uri"``), inline images appear in ``html`` as base64 ``data:``
+    URIs. Set to ``"cid"`` to keep the original ``<img src="cid:..." />``
+    references instead, each of which matches the ``content_id`` of an attachment.
     """
 
 
@@ -214,6 +223,17 @@ class Receiving:
             before (NotRequired[str]): Return emails before this cursor for pagination.
         """
 
+    class GetParams(_GetParams):
+        """
+        GetParams is the class that wraps the query parameters for the get method.
+
+        Attributes:
+            html_format (NotRequired[Literal["data_uri", "cid"]]): Controls how
+                inline images are returned inside ``html``. Defaults to
+                ``"data_uri"`` (base64 data URIs); use ``"cid"`` to keep the
+                original ``cid:`` references.
+        """
+
     class ListResponse(_ListResponse):
         """
         ListResponse is the type that wraps the response for listing received emails.
@@ -225,18 +245,23 @@ class Receiving:
         """
 
     @classmethod
-    def get(cls, email_id: str) -> ReceivedEmail:
+    def get(
+        cls, email_id: str, params: Optional[GetParams] = None
+    ) -> ReceivedEmail:
         """
         Retrieve a single received email.
         see more: https://resend.com/docs/api-reference/emails/retrieve-received-email
 
         Args:
             email_id (str): The ID of the received email to retrieve
+            params (Optional[GetParams]): Optional query parameters (e.g. html_format)
 
         Returns:
             ReceivedEmail: The received email object
         """
-        path = f"/emails/receiving/{email_id}"
+        base_path = f"/emails/receiving/{email_id}"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
         resp = request.Request[ReceivedEmail](
             path=path,
             params={},
@@ -267,18 +292,23 @@ class Receiving:
         return resp
 
     @classmethod
-    async def get_async(cls, email_id: str) -> ReceivedEmail:
+    async def get_async(
+        cls, email_id: str, params: Optional[GetParams] = None
+    ) -> ReceivedEmail:
         """
         Retrieve a single received email (async).
         see more: https://resend.com/docs/api-reference/emails/retrieve-received-email
 
         Args:
             email_id (str): The ID of the received email to retrieve
+            params (Optional[GetParams]): Optional query parameters (e.g. html_format)
 
         Returns:
             ReceivedEmail: The received email object
         """
-        path = f"/emails/receiving/{email_id}"
+        base_path = f"/emails/receiving/{email_id}"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
         resp = await AsyncRequest[ReceivedEmail](
             path=path,
             params={},

--- a/tests/emails_test.py
+++ b/tests/emails_test.py
@@ -388,6 +388,62 @@ class TestResendEmail(ResendBaseTest):
         assert calendar["content_disposition"] is None
         assert calendar["content_id"] is None
 
+    def test_receiving_get_with_html_format_cid(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "inbound",
+                "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+                "to": ["received@example.com"],
+                "from": "sender@example.com",
+                "created_at": "2023-04-07T23:13:52.669661+00:00",
+                "subject": "Test inbound email",
+                "html": '<img src="cid:img001" />',
+                "text": "hello world",
+                "bcc": None,
+                "cc": None,
+                "reply_to": None,
+                "attachments": [],
+            }
+        )
+
+        params: EmailsReceiving.GetParams = {"html_format": "cid"}
+        email: resend.ReceivedEmail = resend.Emails.Receiving.get(
+            email_id="67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+            params=params,
+        )
+        assert email["id"] == "67d9bcdb-5a02-42d7-8da9-0d6feea18cff"
+        self.mock.assert_called_with(
+            url="https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff?html_format=cid"
+        )
+
+    def test_receiving_get_with_html_format_data_uri(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "inbound",
+                "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+                "to": ["received@example.com"],
+                "from": "sender@example.com",
+                "created_at": "2023-04-07T23:13:52.669661+00:00",
+                "subject": "Test inbound email",
+                "html": '<img src="data:image/png;base64,abc" />',
+                "text": "hello world",
+                "bcc": None,
+                "cc": None,
+                "reply_to": None,
+                "attachments": [],
+            }
+        )
+
+        params: EmailsReceiving.GetParams = {"html_format": "data_uri"}
+        email: resend.ReceivedEmail = resend.Emails.Receiving.get(
+            email_id="67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+            params=params,
+        )
+        assert email["id"] == "67d9bcdb-5a02-42d7-8da9-0d6feea18cff"
+        self.mock.assert_called_with(
+            url="https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff?html_format=data_uri"
+        )
+
     def test_should_receiving_get_raise_exception_when_no_content(self) -> None:
         self.set_mock_json(None)
         with self.assertRaises(NoContentError):

--- a/tests/receiving_async_test.py
+++ b/tests/receiving_async_test.py
@@ -29,6 +29,50 @@ class TestResendReceivingAsync(AsyncResendBaseTest):
         assert email["id"] == "67d9bcdb-5a02-42d7-8da9-0d6feea18cff"
         assert email["object"] == "received_email"
 
+    async def test_receiving_get_async_with_html_format_cid(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+                "object": "received_email",
+                "from": "sender@example.com",
+                "to": ["recipient@example.com"],
+                "subject": "Test subject",
+                "created_at": "2024-01-01T00:00:00Z",
+            }
+        )
+
+        params: EmailsReceiving.GetParams = {"html_format": "cid"}
+        email: resend.ReceivedEmail = await resend.Emails.Receiving.get_async(
+            email_id="67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+            params=params,
+        )
+        assert email["id"] == "67d9bcdb-5a02-42d7-8da9-0d6feea18cff"
+        self.mock.assert_called_with(
+            url="https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff?html_format=cid"
+        )
+
+    async def test_receiving_get_async_with_html_format_data_uri(self) -> None:
+        self.set_mock_json(
+            {
+                "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+                "object": "received_email",
+                "from": "sender@example.com",
+                "to": ["recipient@example.com"],
+                "subject": "Test subject",
+                "created_at": "2024-01-01T00:00:00Z",
+            }
+        )
+
+        params: EmailsReceiving.GetParams = {"html_format": "data_uri"}
+        email: resend.ReceivedEmail = await resend.Emails.Receiving.get_async(
+            email_id="67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+            params=params,
+        )
+        assert email["id"] == "67d9bcdb-5a02-42d7-8da9-0d6feea18cff"
+        self.mock.assert_called_with(
+            url="https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff?html_format=data_uri"
+        )
+
     async def test_should_get_receiving_async_raise_exception_when_no_content(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #217

docs: https://resend.com/docs/api-reference/emails/retrieve-received-email#query-parameters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the `html_format` query parameter when retrieving a received email, allowing `cid` or `data_uri` inline images (default is `data_uri`). Aligns the SDK with the API docs and fulfills Linear DEV-990.

- **New Features**
  - Added `GetParams` with optional `html_format: Literal["data_uri", "cid"]`.
  - `get` and `get_async` now accept `params` and append the query via `PaginationHelper.build_paginated_path`.

- **Refactors**
  - Formatted `_receiving.py` to satisfy flake8 E302 and added sync/async tests covering `html_format` URLs.

<sup>Written for commit 911ca816df45d60f2999dc9c4cf3dad503c88964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

