### PR TITLE
feat: add email.scheduled and email.suppressed to WebhookEvent

### DIFF
--- a/resend/webhooks/_webhook.py
+++ b/resend/webhooks/_webhook.py
@@ -7,6 +7,7 @@ WebhookStatus = Literal["enabled", "disabled"]
 WebhookEvent = Literal[
     # Email events
     "email.sent",
+    "email.scheduled",
     "email.delivered",
     "email.delivery_delayed",
     "email.complained",
@@ -15,6 +16,7 @@ WebhookEvent = Literal[
     "email.clicked",
     "email.received",
     "email.failed",
+    "email.suppressed",
     # Contact events
     "contact.created",
     "contact.updated",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `email.scheduled` and `email.suppressed` to `WebhookEvent` for parity with Resend webhooks. This enables typed handling for scheduled and suppressed email events and avoids false “unknown event” type errors.

<sup>Written for commit 7c36cfb257f90081fc03c290edc562292578fd4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

