### PR TITLE
chore: bump version to 2.31.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.30.1"
+__version__ = "2.31.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend` version to 2.31.0 to prepare the next release. No functional code changes.

<sup>Written for commit 7af44cf8115c3504903fc9de302fb97db1b02fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

