### PR TITLE
fix: contact imports segments typing

### DIFF
--- a/examples/contact_imports.py
+++ b/examples/contact_imports.py
@@ -25,7 +25,7 @@ create_params: resend.ContactImports.CreateParams = {
         },
     },
     "on_conflict": "upsert",
-    "segments": ["60a2ac5e-0774-456e-817d-ebf40f6dba31"],
+    "segments": [{"id": "60a2ac5e-0774-456e-817d-ebf40f6dba31"}],
     "topics": [
         {
             "id": "6eb54030-9489-4e9c-8de6-cd337c5fef1e",

--- a/resend/contacts/imports/_contact_imports.py
+++ b/resend/contacts/imports/_contact_imports.py
@@ -61,10 +61,11 @@ class ContactImports:
         """
         Strategy when an imported contact already exists: 'upsert' or 'skip' (default 'skip').
         """
-        segments: NotRequired[List[str]]
+        segments: NotRequired[List[Dict[str, str]]]
         """
-        List of segment IDs to add imported contacts to.
-        Will be serialized as [{"id": "..."}] before sending.
+        List of segment objects to add imported contacts to.
+        Each entry must have an 'id' key with the segment UUID.
+        Example: [{"id": "60a2ac5e-0774-456e-817d-ebf40f6dba31"}]
         """
         topics: NotRequired[List[Dict[str, str]]]
         """
@@ -106,9 +107,7 @@ class ContactImports:
         if "on_conflict" in params:
             form_data["on_conflict"] = params["on_conflict"]
         if "segments" in params:
-            form_data["segments"] = json_lib.dumps(
-                [{"id": sid} for sid in params["segments"]]
-            )
+            form_data["segments"] = json_lib.dumps(params["segments"])
         if "topics" in params:
             form_data["topics"] = json_lib.dumps(params["topics"])
         return files, form_data

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.32.0"
+__version__ = "2.32.1"
 
 
 def get_version() -> str:

--- a/tests/contact_imports_test.py
+++ b/tests/contact_imports_test.py
@@ -27,7 +27,7 @@ class TestContactImports(ResendBaseTest):
             "filename": "contacts.csv",
             "on_conflict": "upsert",
             "column_map": {"email": "email", "first_name": "first_name"},
-            "segments": ["seg-123"],
+            "segments": [{"id": "seg-123"}],
         }
         resp = resend.Contacts.Imports.create(params)
         assert resp["id"] == "479e3145-dd38-476b-932c-529ceb705947"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes contact import segments to accept an array of segment objects instead of string IDs, aligning with the API. Examples/tests updated and version bumped to `2.32.1`.

- **Bug Fixes**
  - `CreateParams.segments` now expects `[{"id": "uuid"}]` and is sent as-is; removed conversion from string IDs.

- **Migration**
  - Change `segments=["60a2ac5e-0774-456e-817d-ebf40f6dba31"]` to `segments=[{"id": "60a2ac5e-0774-456e-817d-ebf40f6dba31"}]`.

<sup>Written for commit 57c35cb3c78a75a3173f836a9e972b2fa387e572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

