### PR TITLE
fix: use Contacts.Imports nested class for consistent type namespacing

### DIFF
--- a/examples/contact_imports.py
+++ b/examples/contact_imports.py
@@ -11,7 +11,7 @@ csv_path = os.path.join(os.path.dirname(__file__), "contacts.csv")
 with open(csv_path, "rb") as f:
     file_content = f.read().replace(b"steve@example.com,Steve,Wozniak", f"steve+{ts}@example.com,Steve,Wozniak".encode())
 
-create_params: resend.ContactImports.CreateParams = {
+create_params: resend.Contacts.Imports.CreateParams = {
     "file": file_content,
     "column_map": {
         "email": "Email",
@@ -34,7 +34,7 @@ create_params: resend.ContactImports.CreateParams = {
     ],
 }
 
-import_response: resend.ContactImports.CreateContactImportResponse = (
+import_response: resend.Contacts.Imports.CreateContactImportResponse = (
     resend.Contacts.Imports.create(create_params)
 )
 print("Created contact import with ID: {}".format(import_response["id"]))
@@ -44,7 +44,7 @@ contact_import: resend.ContactImport = resend.Contacts.Imports.get(import_respon
 print("Retrieved contact import")
 print(contact_import)
 
-list_response: resend.ContactImports.ListContactImportsResponse = (
+list_response: resend.Contacts.Imports.ListContactImportsResponse = (
     resend.Contacts.Imports.list()
 )
 print(f"Found {len(list_response['data'])} imports")

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -22,7 +22,9 @@ class Contacts:
     # Sub-API for managing contact-segment associations
     Segments = ContactSegments
     Topics = Topics
-    Imports = ContactImports
+
+    class Imports(ContactImports):
+        pass
 
     class RemoveContactResponse(BaseResponse):
         """

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.32.1"
+__version__ = "2.32.2"
 
 
 def get_version() -> str:

--- a/tests/contact_imports_test.py
+++ b/tests/contact_imports_test.py
@@ -10,10 +10,10 @@ class TestContactImports(ResendBaseTest):
             {"object": "contact_import", "id": "479e3145-dd38-476b-932c-529ceb705947"}
         )
 
-        params: resend.ContactImports.CreateParams = {
+        params: resend.Contacts.Imports.CreateParams = {
             "file": b"email,first_name\nsteve@example.com,Steve",
         }
-        resp: resend.ContactImports.CreateContactImportResponse = resend.Contacts.Imports.create(params)
+        resp: resend.Contacts.Imports.CreateContactImportResponse = resend.Contacts.Imports.create(params)
         assert resp["id"] == "479e3145-dd38-476b-932c-529ceb705947"
         assert resp["object"] == "contact_import"
 
@@ -22,7 +22,7 @@ class TestContactImports(ResendBaseTest):
             {"object": "contact_import", "id": "479e3145-dd38-476b-932c-529ceb705947"}
         )
 
-        params: resend.ContactImports.CreateParams = {
+        params: resend.Contacts.Imports.CreateParams = {
             "file": b"email,first_name\nsteve@example.com,Steve",
             "filename": "contacts.csv",
             "on_conflict": "upsert",
@@ -84,7 +84,7 @@ class TestContactImports(ResendBaseTest):
             }
         )
 
-        result: resend.ContactImports.ListContactImportsResponse = resend.Contacts.Imports.list()
+        result: resend.Contacts.Imports.ListContactImportsResponse = resend.Contacts.Imports.list()
         assert result["object"] == "list"
         assert result["has_more"] is False
         assert len(result["data"]) == 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes contact import types under `resend.Contacts.Imports` for consistent namespacing. Adds a nested `Imports` class to `Contacts`, updates examples/tests to use `resend.Contacts.Imports.*`, and bumps version to 2.32.2; no runtime change.

<sup>Written for commit 7c845cc4e31fee0b55a3a57abd926861ab205228. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

