### PR TITLE
feat: add received_for to ReceivedEmail type

### DIFF
--- a/resend/emails/_received_email.py
+++ b/resend/emails/_received_email.py
@@ -152,6 +152,10 @@ class _ReceivedEmailDefaultAttrs(_ReceivedEmailFromParam, BaseResponse):
     """
     Reply-to addresses.
     """
+    received_for: List[str]
+    """
+    Addresses the email was received for (forwarding recipients).
+    """
     message_id: str
     """
     The message ID of the email.
@@ -182,6 +186,7 @@ class ReceivedEmail(_ReceivedEmailDefaultAttrs):
         bcc (Optional[List[str]]): Bcc recipients.
         cc (Optional[List[str]]): Cc recipients.
         reply_to (Optional[List[str]]): Reply-to addresses.
+        received_for (List[str]): Addresses the email was received for (forwarding recipients).
         message_id (str): The message ID of the email.
         headers (NotRequired[Dict[str, str]]): Email headers.
         attachments (List[EmailAttachment]): List of attachments.

--- a/tests/receiving_async_test.py
+++ b/tests/receiving_async_test.py
@@ -20,6 +20,7 @@ class TestResendReceivingAsync(AsyncResendBaseTest):
                 "to": ["recipient@example.com"],
                 "subject": "Test subject",
                 "created_at": "2024-01-01T00:00:00Z",
+                "received_for": ["forwarded@example.com"],
             }
         )
 
@@ -28,6 +29,7 @@ class TestResendReceivingAsync(AsyncResendBaseTest):
         )
         assert email["id"] == "67d9bcdb-5a02-42d7-8da9-0d6feea18cff"
         assert email["object"] == "received_email"
+        assert email["received_for"] == ["forwarded@example.com"]
 
     async def test_should_get_receiving_async_raise_exception_when_no_content(
         self,


### PR DESCRIPTION
Adds the received_for field to the received email response type, matching the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the received_for field to the ReceivedEmail response type to mirror the API and expose forwarding recipients; update the async receiving test to assert this field.

<sup>Written for commit 08251e2dd78e12cd6daaa29023fc61806ed79efb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

