### PR TITLE
chore: update sync_prs_to_linear sha

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@235fbe2ab5eff9198d18f0b4608eb0b8ddc52ede
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@9dd949340245057c074a4c0c96d9d7a7df22b655
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
updating the sync_prs_to_linear sha

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pinned SHA of `resend/public-shared-workflows/.github/actions/sync_prs_to_linear` to `@9dd9493` to pick up upstream fixes and keep PR-to-Linear syncing reliable.

<sup>Written for commit ddf5a8eb38361a2a9fa84606ced6487fa1fd0a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

