### PR TITLE
fix: add async audience aliases

### DIFF
--- a/resend/audiences/_audiences.py
+++ b/resend/audiences/_audiences.py
@@ -195,3 +195,91 @@ class Audiences:
             stacklevel=2,
         )
         return Segments.remove(id)
+
+    @classmethod
+    async def create_async(cls, params: CreateParams) -> CreateAudienceResponse:
+        """
+        Create a list of contacts (async).
+        see more: https://resend.com/docs/api-reference/audiences/create-audience
+
+        Args:
+            params (CreateParams): The audience creation parameters
+
+        Returns:
+            CreateAudienceResponse: The created audience response
+
+        .. deprecated::
+            Use Segments.create_async() instead. Audiences is now an alias for Segments.
+        """
+        warnings.warn(
+            "Audiences is deprecated. Use Segments instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await Segments.create_async(params)
+
+    @classmethod
+    async def list_async(cls, params: Optional[ListParams] = None) -> ListResponse:
+        """
+        Retrieve a list of audiences (async).
+        see more: https://resend.com/docs/api-reference/audiences/list-audiences
+
+        Args:
+            params (Optional[ListParams]): Optional pagination parameters
+
+        Returns:
+            ListResponse: A list of audience objects
+
+        .. deprecated::
+            Use Segments.list_async() instead. Audiences is now an alias for Segments.
+        """
+        warnings.warn(
+            "Audiences is deprecated. Use Segments instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await Segments.list_async(params)
+
+    @classmethod
+    async def get_async(cls, id: str) -> Audience:
+        """
+        Retrieve a single audience (async).
+        see more: https://resend.com/docs/api-reference/audiences/get-audience
+
+        Args:
+            id (str): The audience ID
+
+        Returns:
+            Audience: The audience object
+
+        .. deprecated::
+            Use Segments.get_async() instead. Audiences is now an alias for Segments.
+        """
+        warnings.warn(
+            "Audiences is deprecated. Use Segments instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await Segments.get_async(id)
+
+    @classmethod
+    async def remove_async(cls, id: str) -> RemoveAudienceResponse:
+        """
+        Delete a single audience (async).
+        see more: https://resend.com/docs/api-reference/audiences/delete-audience
+
+        Args:
+            id (str): The audience ID
+
+        Returns:
+            RemoveAudienceResponse: The removed audience response
+
+        .. deprecated::
+            Use Segments.remove_async() instead. Audiences is now an alias for Segments.
+        """
+        warnings.warn(
+            "Audiences is deprecated. Use Segments instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await Segments.remove_async(id)

--- a/tests/audiences_async_test.py
+++ b/tests/audiences_async_test.py
@@ -110,3 +110,122 @@ class TestResendSegmentsAsync(AsyncResendBaseTest):
         self.set_mock_json(None)
         with pytest.raises(NoContentError):
             _ = await resend.Segments.list_async()
+
+
+class TestResendAudiencesAsync(AsyncResendBaseTest):
+    async def test_audiences_create_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "audience",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+                "name": "Registered Users",
+            }
+        )
+
+        params: resend.Audiences.CreateParams = {
+            "name": "Python SDK Audience",
+        }
+        with pytest.warns(DeprecationWarning):
+            audience = await resend.Audiences.create_async(params)
+        assert audience["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert audience["name"] == "Registered Users"
+
+    async def test_should_create_audiences_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        params: resend.Audiences.CreateParams = {
+            "name": "Python SDK Audience",
+        }
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(NoContentError):
+                _ = await resend.Audiences.create_async(params)
+
+    async def test_audiences_get_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "audience",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+                "name": "Registered Users",
+                "created_at": "2023-10-06T22:59:55.977Z",
+            }
+        )
+
+        with pytest.warns(DeprecationWarning):
+            audience = await resend.Audiences.get_async(
+                id="78261eea-8f8b-4381-83c6-79fa7120f1cf"
+            )
+        assert audience["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert audience["name"] == "Registered Users"
+        assert audience["created_at"] == "2023-10-06T22:59:55.977Z"
+
+    async def test_should_get_audiences_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(NoContentError):
+                _ = await resend.Audiences.get_async(
+                    id="78261eea-8f8b-4381-83c6-79fa7120f1cf"
+                )
+
+    async def test_audiences_remove_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "audience",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+                "deleted": True,
+            }
+        )
+
+        with pytest.warns(DeprecationWarning):
+            rmed: resend.Audiences.RemoveAudienceResponse = (
+                await resend.Audiences.remove_async(
+                    "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+                )
+            )
+        assert rmed["object"] == "audience"
+        assert rmed["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert rmed["deleted"] is True
+
+    async def test_should_remove_audiences_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(NoContentError):
+                _ = await resend.Audiences.remove_async(
+                    id="78261eea-8f8b-4381-83c6-79fa7120f1cf"
+                )
+
+    async def test_audiences_list_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+                        "name": "Registered Users",
+                        "created_at": "2023-10-06T22:59:55.977Z",
+                    }
+                ],
+            }
+        )
+
+        with pytest.warns(DeprecationWarning):
+            audiences: resend.Audiences.ListResponse = (
+                await resend.Audiences.list_async()
+            )
+        assert audiences["object"] == "list"
+        assert audiences["has_more"] is False
+        assert audiences["data"][0]["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert audiences["data"][0]["name"] == "Registered Users"
+
+    async def test_should_list_audiences_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(NoContentError):
+                _ = await resend.Audiences.list_async()


### PR DESCRIPTION
What
- Adds async methods to the deprecated `Audiences` alias so it mirrors `Segments` async support.
- Covers create/get/list/remove async alias behavior and deprecation warnings.

Why
- `Audiences` delegates sync calls to `Segments`, but the async alias methods were missing. Users on the deprecated alias could not use the async SDK surface consistently.

Testing
- `tox -e py -- tests/audiences_async_test.py`
- `tox -e py`
- `tox -e mypy`
- `black --check resend/audiences/_audiences.py tests/audiences_async_test.py`
- `isort --check-only resend/audiences/_audiences.py tests/audiences_async_test.py`

Note
- Local `tox -e lint` is blocked on this machine because `flake8<5` is incompatible with the available Python 3.12/3.14 entry-point API. CI runs lint on Python 3.8-3.11 per `.github/workflows/ci.yaml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds async support to the deprecated `Audiences` alias to match `Segments`, restoring parity for users relying on `Audiences`.
Users can now call async create/get/list/remove on `Audiences` and receive deprecation warnings.

- **Bug Fixes**
  - Added `create_async`, `get_async`, `list_async`, `remove_async` on `Audiences`, delegating to `Segments` and emitting `DeprecationWarning`.
  - Added tests in `tests/audiences_async_test.py` covering success and `NoContentError` paths.

<sup>Written for commit 87f65edc4252e4ce490b0da7c69e378457294526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

