### PR TITLE
fix: return api key delete response

### DIFF
--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -57,6 +57,29 @@ class ApiKeys:
         The token of the created API key
         """
 
+    class DeleteApiKeyResponse(BaseResponse):
+        """
+        DeleteApiKeyResponse is the type that wraps the deleted API key response.
+
+        Attributes:
+            object (str): The object type, always "api_key"
+            id (str): The ID of the deleted API key
+            deleted (bool): Whether the API key was deleted
+        """
+
+        object: str
+        """
+        The object type, always "api_key"
+        """
+        id: str
+        """
+        The ID of the deleted API key
+        """
+        deleted: bool
+        """
+        Whether the API key was deleted
+        """
+
     class ListParams(TypedDict):
         limit: NotRequired[int]
         """
@@ -134,7 +157,7 @@ class ApiKeys:
         return resp
 
     @classmethod
-    def remove(cls, api_key_id: str) -> None:
+    def remove(cls, api_key_id: str) -> DeleteApiKeyResponse:
         """
         Remove an existing API key.
         see more: https://resend.com/docs/api-reference/api-keys/delete-api-key
@@ -143,13 +166,13 @@ class ApiKeys:
             api_key_id (str): The ID of the API key to remove
 
         Returns:
-            None
+            DeleteApiKeyResponse: The deleted API key response
         """
         path = f"/api-keys/{api_key_id}"
-
-        # This would raise if failed
-        request.Request[None](path=path, params={}, verb="delete").perform()
-        return None
+        resp = request.Request[ApiKeys.DeleteApiKeyResponse](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp
 
     @classmethod
     async def create_async(cls, params: CreateParams) -> CreateApiKeyResponse:
@@ -190,7 +213,7 @@ class ApiKeys:
         return resp
 
     @classmethod
-    async def remove_async(cls, api_key_id: str) -> None:
+    async def remove_async(cls, api_key_id: str) -> DeleteApiKeyResponse:
         """
         Remove an existing API key (async).
         see more: https://resend.com/docs/api-reference/api-keys/delete-api-key
@@ -199,10 +222,10 @@ class ApiKeys:
             api_key_id (str): The ID of the API key to remove
 
         Returns:
-            None
+            DeleteApiKeyResponse: The deleted API key response
         """
         path = f"/api-keys/{api_key_id}"
-
-        # This would raise if failed
-        await AsyncRequest[None](path=path, params={}, verb="delete").perform()
-        return None
+        resp = await AsyncRequest[ApiKeys.DeleteApiKeyResponse](
+            path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp

--- a/tests/api_keys_async_test.py
+++ b/tests/api_keys_async_test.py
@@ -61,9 +61,19 @@ class TestResendApiKeysAsync(AsyncResendBaseTest):
             _ = await resend.ApiKeys.list_async()
 
     async def test_api_keys_remove_async(self) -> None:
-        self.set_mock_text("")
-
-        # Remove operation returns None, verify no exceptions raised
-        await resend.ApiKeys.remove_async(
-            api_key_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+        self.set_mock_json(
+            {
+                "object": "api_key",
+                "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+                "deleted": True,
+            }
         )
+
+        deleted_key: resend.ApiKeys.DeleteApiKeyResponse = (
+            await resend.ApiKeys.remove_async(
+                api_key_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            )
+        )
+        assert deleted_key["object"] == "api_key"
+        assert deleted_key["id"] == "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+        assert deleted_key["deleted"] is True

--- a/tests/api_keys_test.py
+++ b/tests/api_keys_test.py
@@ -128,11 +128,17 @@ class TestResendApiKeys(ResendBaseTest):
         assert keys["data"][0]["id"] == "test-key-3"
 
     def test_api_keys_remove(self) -> None:
-        self.set_mock_text("")
-
-        assert (
-            resend.ApiKeys.remove(
-                api_key_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
-            )
-            is None
+        self.set_mock_json(
+            {
+                "object": "api_key",
+                "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+                "deleted": True,
+            }
         )
+
+        deleted_key: resend.ApiKeys.DeleteApiKeyResponse = resend.ApiKeys.remove(
+            api_key_id="4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+        )
+        assert deleted_key["object"] == "api_key"
+        assert deleted_key["id"] == "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+        assert deleted_key["deleted"] is True


### PR DESCRIPTION
What
- Adds a typed delete response for API key deletion.
- Returns the documented delete response from sync and async remove methods.

Why
- The Delete API key endpoint returns an object with object, id, and deleted fields, but the SDK previously discarded the response body and returned None.

Testing
- pytest --cov=resend --cov-report=xml --doctest-modules tests/api_keys_test.py tests/api_keys_async_test.py -q
- black --check resend/api_keys/_api_keys.py tests/api_keys_test.py tests/api_keys_async_test.py
- isort --check-only resend/api_keys/_api_keys.py tests/api_keys_test.py tests/api_keys_async_test.py
- mypy --install-types --non-interactive --ignore-missing-imports resend/ examples/ tests/
- pytest --cov=resend --cov-report=xml --doctest-modules tests -q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the documented API key delete response instead of None, so callers can confirm deletion. Adds `ApiKeys.DeleteApiKeyResponse` and updates `ApiKeys.remove`/`remove_async` in `resend`.

- **Bug Fixes**
  - `ApiKeys.remove` and `ApiKeys.remove_async` now return `ApiKeys.DeleteApiKeyResponse` with `object`, `id`, and `deleted`.
  - Switch to `perform_with_content` to parse the delete response; tests updated to assert returned fields.

<sup>Written for commit 5cdc6085dcc2e1dfa41cb5f5269a098da0d617c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

