### PR TITLE
feat: add Batch.SendParams with tags support

### DIFF
--- a/examples/async/batch_email_send_async.py
+++ b/examples/async/batch_email_send_async.py
@@ -12,7 +12,7 @@ if not os.environ["RESEND_API_KEY"]:
 
 
 async def main() -> None:
-    params: List[resend.Emails.SendParams] = [
+    params: List[resend.Batch.SendParams] = [
         {
             "from": "onboarding@resend.dev",
             "to": ["delivered@resend.dev"],

--- a/examples/batch_email_send.py
+++ b/examples/batch_email_send.py
@@ -8,7 +8,7 @@ if not os.environ["RESEND_API_KEY"]:
     raise EnvironmentError("RESEND_API_KEY is missing")
 
 
-params: List[resend.Emails.SendParams] = [
+params: List[resend.Batch.SendParams] = [
     {
         "from": "onboarding@resend.dev",
         "to": ["delivered@resend.dev"],
@@ -55,7 +55,7 @@ try:
     print("sending with permissive validation mode")
 
     # Example with some invalid emails to demonstrate error handling
-    mixed_params: List[resend.Emails.SendParams] = [
+    mixed_params: List[resend.Batch.SendParams] = [
         {
             "from": "onboarding@resend.dev",
             "to": ["delivered@resend.dev"],

--- a/resend/emails/_batch.py
+++ b/resend/emails/_batch.py
@@ -5,7 +5,7 @@ from typing_extensions import Literal, NotRequired, TypedDict
 from resend import request
 from resend._base_response import BaseResponse
 
-from ._emails import Emails
+from ._emails import _BatchSendParamsDefault
 
 # Async imports (optional - only available with pip install resend[async])
 try:
@@ -42,7 +42,7 @@ class BatchValidationError(TypedDict):
 
 class Batch:
 
-    class SendParams(Emails.SendParams):
+    class SendParams(_BatchSendParamsDefault):
         """SendParams is the class that wraps the parameters for each email in a batch send.
 
         Attributes:
@@ -55,11 +55,12 @@ class Batch:
             html (NotRequired[str]): The HTML content of the email.
             text (NotRequired[str]): The text content of the email.
             headers (NotRequired[Dict[str, str]]): Custom headers to be added to the email.
-            attachments (NotRequired[List[Union[Attachment, RemoteAttachment]]]): List of attachments to be added to the email.
             tags (NotRequired[List[Tag]]): List of tags to be added to the email.
-            scheduled_at (NotRequired[str]): Schedule email to be sent later.
-            The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
             template (NotRequired[EmailTemplate]): Template configuration for sending emails using predefined templates.
+
+        Note:
+            The batch API does not support `attachments` or `scheduled_at`.
+            Use the single email endpoint for those features.
         """
 
     class SendOptions(TypedDict):

--- a/resend/emails/_batch.py
+++ b/resend/emails/_batch.py
@@ -57,10 +57,6 @@ class Batch:
             headers (NotRequired[Dict[str, str]]): Custom headers to be added to the email.
             tags (NotRequired[List[Tag]]): List of tags to be added to the email.
             template (NotRequired[EmailTemplate]): Template configuration for sending emails using predefined templates.
-
-        Note:
-            The batch API does not support `attachments` or `scheduled_at`.
-            Use the single email endpoint for those features.
         """
 
     class SendOptions(TypedDict):

--- a/resend/emails/_batch.py
+++ b/resend/emails/_batch.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -42,6 +42,26 @@ class BatchValidationError(TypedDict):
 
 class Batch:
 
+    class SendParams(Emails.SendParams):
+        """SendParams is the class that wraps the parameters for each email in a batch send.
+
+        Attributes:
+            from (NotRequired[str]): The email address to send the email from.
+            to (Union[str, List[str]]): List of email addresses to send the email to.
+            subject (NotRequired[str]): The subject of the email.
+            bcc (NotRequired[Union[List[str], str]]): Bcc
+            cc (NotRequired[Union[List[str], str]]): Cc
+            reply_to (NotRequired[Union[List[str], str]]): Reply to
+            html (NotRequired[str]): The HTML content of the email.
+            text (NotRequired[str]): The text content of the email.
+            headers (NotRequired[Dict[str, str]]): Custom headers to be added to the email.
+            attachments (NotRequired[List[Union[Attachment, RemoteAttachment]]]): List of attachments to be added to the email.
+            tags (NotRequired[List[Tag]]): List of tags to be added to the email.
+            scheduled_at (NotRequired[str]): Schedule email to be sent later.
+            The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
+            template (NotRequired[EmailTemplate]): Template configuration for sending emails using predefined templates.
+        """
+
     class SendOptions(TypedDict):
         """
         SendOptions is the class that wraps the options for the batch send method.
@@ -79,14 +99,14 @@ class Batch:
 
     @classmethod
     def send(
-        cls, params: List[Emails.SendParams], options: Optional[SendOptions] = None
+        cls, params: List[SendParams], options: Optional[SendOptions] = None
     ) -> SendResponse:
         """
         Trigger up to 100 batch emails at once.
         see more: https://resend.com/docs/api-reference/emails/send-batch-emails
 
         Args:
-            params (List[Emails.SendParams]): The list of emails to send
+            params (List[SendParams]): The list of emails to send
             options (Optional[SendOptions]): Batch options, including batch_validation mode
 
         Returns:
@@ -104,14 +124,14 @@ class Batch:
 
     @classmethod
     async def send_async(
-        cls, params: List[Emails.SendParams], options: Optional[SendOptions] = None
+        cls, params: List[SendParams], options: Optional[SendOptions] = None
     ) -> SendResponse:
         """
         Trigger up to 100 batch emails at once (async).
         see more: https://resend.com/docs/api-reference/emails/send-batch-emails
 
         Args:
-            params (List[Emails.SendParams]): The list of emails to send
+            params (List[SendParams]): The list of emails to send
             options (Optional[SendOptions]): Batch options, ie: idempotency_key
 
         Returns:

--- a/resend/emails/_batch.py
+++ b/resend/emails/_batch.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, cast
 
 from typing_extensions import Literal, NotRequired, TypedDict
 

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -181,6 +181,8 @@ class Emails:
             headers (NotRequired[Dict[str, str]]): Custom headers to be added to the email.
             attachments (NotRequired[List[Union[Attachment, RemoteAttachment]]]): List of attachments to be added to the email.
             tags (NotRequired[List[Tag]]): List of tags to be added to the email.
+            scheduled_at (NotRequired[str]): Schedule email to be sent later.
+            The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
             template (NotRequired[EmailTemplate]): Template configuration for sending emails using predefined templates.
         """
 

--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -134,6 +134,49 @@ class _SendParamsDefault(_SendParamsFrom):
     """
 
 
+class _BatchSendParamsDefault(_SendParamsFrom):
+    to: Union[str, List[str]]
+    """
+    List of email addresses to send the email to.
+    """
+    subject: NotRequired[str]
+    """
+    The subject of the email.
+    """
+    bcc: NotRequired[Union[List[str], str]]
+    """
+    Bcc
+    """
+    cc: NotRequired[Union[List[str], str]]
+    """
+    Cc
+    """
+    reply_to: NotRequired[Union[List[str], str]]
+    """
+    Reply to
+    """
+    html: NotRequired[str]
+    """
+    The HTML content of the email.
+    """
+    text: NotRequired[str]
+    """
+    The text content of the email.
+    """
+    headers: NotRequired[Dict[str, str]]
+    """
+    Custom headers to be added to the email.
+    """
+    tags: NotRequired[List[Tag]]
+    """
+    List of tags to be added to the email.
+    """
+    template: NotRequired[EmailTemplate]
+    """
+    Template configuration for sending emails using predefined templates.
+    """
+
+
 class Emails:
     Attachments = Attachments
     Receiving = Receiving

--- a/tests/batch_emails_async_test.py
+++ b/tests/batch_emails_async_test.py
@@ -22,7 +22,7 @@ class TestResendBatchSendAsync(AsyncResendBaseTest):
             }
         )
 
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -52,7 +52,7 @@ class TestResendBatchSendAsync(AsyncResendBaseTest):
             }
         )
 
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -82,7 +82,7 @@ class TestResendBatchSendAsync(AsyncResendBaseTest):
         self,
     ) -> None:
         self.set_mock_json(None)
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],

--- a/tests/batch_emails_test.py
+++ b/tests/batch_emails_test.py
@@ -170,18 +170,12 @@ class TestResendBatchSend(ResendBaseTest):
         assert emails["errors"][0]["index"] == 1
         assert emails["errors"][0]["message"] == "The `to` field is missing."
 
-    def test_batch_email_send_with_tags_attachments_and_scheduled_at(self) -> None:
+    def test_batch_email_send_with_tags(self) -> None:
         self.set_mock_json(
             {
                 "data": [{"id": "ae2014de-c168-4c61-8267-70d2662a1ce1"}]
             }
         )
-
-        attachment: resend.Attachment = {
-            "filename": "invoice.pdf",
-            "content": [1, 2, 3],
-            "content_type": "application/pdf",
-        }
 
         params: List[resend.Batch.SendParams] = [
             {
@@ -190,8 +184,6 @@ class TestResendBatchSend(ResendBaseTest):
                 "subject": "hey",
                 "html": "<strong>hello, world!</strong>",
                 "tags": [{"name": "category", "value": "notification"}],
-                "scheduled_at": "2024-09-05T11:52:01.858Z",
-                "attachments": [attachment],
             }
         ]
 
@@ -209,5 +201,3 @@ class TestResendBatchSend(ResendBaseTest):
 
         sent_params = captured_params[0]
         assert sent_params[0]["tags"] == [{"name": "category", "value": "notification"}]
-        assert sent_params[0]["scheduled_at"] == "2024-09-05T11:52:01.858Z"
-        assert sent_params[0]["attachments"][0]["filename"] == "invoice.pdf"

--- a/tests/batch_emails_test.py
+++ b/tests/batch_emails_test.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 from unittest.mock import patch
 
 import resend
@@ -195,12 +195,12 @@ class TestResendBatchSend(ResendBaseTest):
             }
         ]
 
-        captured_params: list = []
+        captured_params: List[Any] = []
         original_init = request.Request.__init__
 
-        def capturing_init(instance, *args, **kwargs):
+        def capturing_init(instance: Any, *args: Any, **kwargs: Any) -> None:
             captured_params.append(kwargs.get("params"))
-            return original_init(instance, *args, **kwargs)
+            original_init(instance, *args, **kwargs)
 
         with patch.object(request.Request, "__init__", capturing_init):
             emails: resend.Batch.SendResponse = resend.Batch.send(params)

--- a/tests/batch_emails_test.py
+++ b/tests/batch_emails_test.py
@@ -1,6 +1,8 @@
 from typing import List
+from unittest.mock import patch
 
 import resend
+from resend import request
 from resend.exceptions import NoContentError
 from tests.conftest import ResendBaseTest
 
@@ -18,7 +20,7 @@ class TestResendBatchSend(ResendBaseTest):
             }
         )
 
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -48,7 +50,7 @@ class TestResendBatchSend(ResendBaseTest):
             }
         )
 
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -74,7 +76,7 @@ class TestResendBatchSend(ResendBaseTest):
 
     def test_should_send_batch_email_raise_exception_when_no_content(self) -> None:
         self.set_mock_json(None)
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -101,7 +103,7 @@ class TestResendBatchSend(ResendBaseTest):
             }
         )
 
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -141,7 +143,7 @@ class TestResendBatchSend(ResendBaseTest):
             }
         )
 
-        params: List[resend.Emails.SendParams] = [
+        params: List[resend.Batch.SendParams] = [
             {
                 "from": "from@resend.dev",
                 "to": ["to@resend.dev"],
@@ -167,3 +169,45 @@ class TestResendBatchSend(ResendBaseTest):
         assert len(emails["errors"]) == 1
         assert emails["errors"][0]["index"] == 1
         assert emails["errors"][0]["message"] == "The `to` field is missing."
+
+    def test_batch_email_send_with_tags_attachments_and_scheduled_at(self) -> None:
+        self.set_mock_json(
+            {
+                "data": [{"id": "ae2014de-c168-4c61-8267-70d2662a1ce1"}]
+            }
+        )
+
+        attachment: resend.Attachment = {
+            "filename": "invoice.pdf",
+            "content": [1, 2, 3],
+            "content_type": "application/pdf",
+        }
+
+        params: List[resend.Batch.SendParams] = [
+            {
+                "from": "from@resend.dev",
+                "to": ["to@resend.dev"],
+                "subject": "hey",
+                "html": "<strong>hello, world!</strong>",
+                "tags": [{"name": "category", "value": "notification"}],
+                "scheduled_at": "2024-09-05T11:52:01.858Z",
+                "attachments": [attachment],
+            }
+        ]
+
+        captured_params: list = []
+        original_init = request.Request.__init__
+
+        def capturing_init(instance, *args, **kwargs):
+            captured_params.append(kwargs.get("params"))
+            return original_init(instance, *args, **kwargs)
+
+        with patch.object(request.Request, "__init__", capturing_init):
+            emails: resend.Batch.SendResponse = resend.Batch.send(params)
+
+        assert emails["data"][0]["id"] == "ae2014de-c168-4c61-8267-70d2662a1ce1"
+
+        sent_params = captured_params[0]
+        assert sent_params[0]["tags"] == [{"name": "category", "value": "notification"}]
+        assert sent_params[0]["scheduled_at"] == "2024-09-05T11:52:01.858Z"
+        assert sent_params[0]["attachments"][0]["filename"] == "invoice.pdf"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch send API supports `tags` per email. This PR adds a dedicated `Batch.SendParams` type that reflects the batch API surface.

## Changes

- Add `_BatchSendParamsDefault` TypedDict for batch email parameters
- Add `Batch.SendParams` with explicit documentation for `tags`
- Update `Batch.send` / `Batch.send_async` signatures to accept `List[Batch.SendParams]`
- Document `scheduled_at` on `Emails.SendParams` (was present in the TypedDict but missing from docs)
- Add a test verifying tags are serialized in the batch request payload
- Update batch examples and tests to use `Batch.SendParams`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-407d3600-cb18-42f5-8d56-41cdb1e43669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-407d3600-cb18-42f5-8d56-41cdb1e43669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a dedicated `Batch.SendParams` for batch sends with per-email `tags`, and clarifies that batch requests do not support `attachments` or `scheduled_at`. Updates method signatures, examples, and tests, and documents `scheduled_at` on `Emails.SendParams`.

- **New Features**
  - Added `Batch.SendParams` (tags only); documented that batch excludes `attachments` and `scheduled_at`; removed attachment references from batch docs; documented `scheduled_at` on `Emails.SendParams`.
  - Updated `Batch.send`/`Batch.send_async` to accept `List[Batch.SendParams]`; examples updated; tests added (including tags serialization).

- **Migration**
  - Replace `List[resend.Emails.SendParams]` with `List[resend.Batch.SendParams]` when calling `Batch.send` or `Batch.send_async`.

<sup>Written for commit 57f72b86a3aaabacd527971f5b068f20a04fc697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

