### PR TITLE
fix: map missing_required_field to MissingRequiredFieldsError

### DIFF
--- a/resend/exceptions.py
+++ b/resend/exceptions.py
@@ -199,6 +199,8 @@ class RateLimitError(ResendError):
 ERRORS: Dict[str, Dict[str, Any]] = {
     "400": {"validation_error": ValidationError},
     "422": {
+        # API docs use singular `missing_required_field`; keep plural as alias.
+        "missing_required_field": MissingRequiredFieldsError,
         "missing_required_fields": MissingRequiredFieldsError,
         "validation_error": ValidationError,
     },
@@ -232,7 +234,8 @@ def raise_for_code_and_type(
             or
         ValidationError: If the error type is validation_error
             or
-        MissingRequiredFieldsError: If the error type is missing_required_fields
+        MissingRequiredFieldsError: If the error type is missing_required_field
+            (or legacy missing_required_fields)
             or
         MissingApiKeyError: If the error type is missing_api_key
             or

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -3,7 +3,8 @@ import unittest
 import pytest
 
 from resend.exceptions import (ApplicationError, MissingApiKeyError,
-                               RateLimitError, ResendError, ValidationError,
+                               MissingRequiredFieldsError, RateLimitError,
+                               ResendError, ValidationError,
                                raise_for_code_and_type)
 
 
@@ -22,6 +23,23 @@ class TestResendError(unittest.TestCase):
         with pytest.raises(ValidationError) as e:
             raise_for_code_and_type(422, "validation_error", "err")
         assert e.type is ValidationError
+
+    def test_missing_required_field_singular(self) -> None:
+        # Resend API docs use singular `missing_required_field`.
+        with pytest.raises(MissingRequiredFieldsError) as e:
+            raise_for_code_and_type(422, "missing_required_field", "Missing `to` field")
+        assert e.type is MissingRequiredFieldsError
+        assert e.value.error_type == "missing_required_field"
+        assert e.value.code == 422
+
+    def test_missing_required_fields_plural_alias(self) -> None:
+        # Keep plural as a backward-compatible alias.
+        with pytest.raises(MissingRequiredFieldsError) as e:
+            raise_for_code_and_type(
+                422, "missing_required_fields", "Missing `to` field"
+            )
+        assert e.type is MissingRequiredFieldsError
+        assert e.value.error_type == "missing_required_fields"
 
     def test_validation_error_from_400(self) -> None:
         with pytest.raises(ValidationError) as e:


### PR DESCRIPTION
## Summary

- Register the documented API error name `missing_required_field` (singular) so it raises `MissingRequiredFieldsError`.
- Keep `missing_required_fields` (plural) as a backward-compatible alias.
- Add unit tests for both names.

## Why

[Resend error docs](https://resend.com/docs/api-reference/errors) define `missing_required_field` (singular). The Python SDK `ERRORS` map only had `missing_required_fields` (plural), so a real 422 with `name: "missing_required_field"` fell through to generic `ResendError`. Callers catching `MissingRequiredFieldsError` never matched.

## Validation (before / after)

Reproducible with the public mapper (no network):

```python
from resend.exceptions import (
    MissingRequiredFieldsError,
    ResendError,
    raise_for_code_and_type,
)

# Before this change:
#   missing_required_field  -> ResendError
#   missing_required_fields -> MissingRequiredFieldsError
#
# After this change:
#   both names -> MissingRequiredFieldsError

for name in ("missing_required_field", "missing_required_fields"):
    try:
        raise_for_code_and_type(422, name, "Missing `to` field")
    except MissingRequiredFieldsError:
        print(name, "-> MissingRequiredFieldsError")
    except ResendError as e:
        print(name, "->", type(e).__name__)
```

Expected after this PR:

```text
missing_required_field -> MissingRequiredFieldsError
missing_required_fields -> MissingRequiredFieldsError
```

Same path as `Request.perform` / `AsyncRequest.perform`, which pass `data["name"]` into `raise_for_code_and_type`.

## Testing

- `pytest tests/exceptions_test.py` (16 passed)
- `mypy resend/exceptions.py tests/exceptions_test.py`
- `flake8 --max-line-length=130 ./resend/exceptions.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly raises `MissingRequiredFieldsError` for 422 responses with the documented `missing_required_field` name, so callers catching this exception now match real API errors.

- **Bug Fixes**
  - Map `missing_required_field` in the 422 `ERRORS` table; keep `missing_required_fields` as a legacy alias.
  - Add unit tests for both names and update the `raise_for_code_and_type` docstring.

<sup>Written for commit e3a1e13ead6b2fc425deee053eb1dc082d8f2352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

