### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **Resend Python SDK** — a client library (published to PyPI as `resend`).
+There is **no server, database, or long-running service**; the only external dependency is the
+Resend REST API (`https://api.resend.com`), which the unit tests mock. Standard dev commands live
+in `tox.ini` (envs: `format`, `lint`, `mypy`, `py`); the update script pre-installs the toolchain.
+
+Non-obvious caveats for this environment:
+
+- **Use `python3`, not `python`** (there is no `python` shim). Console scripts like `tox` install
+  to `~/.local/bin`, which may not be on `PATH`; call `python3 -m <tool>` or add it to `PATH`.
+- **`flake8<5.0.0` (pinned in `tox.ini`) is incompatible with Python 3.12** (the system default),
+  failing with `'EntryPoints' object has no attribute 'get'`. CI only lints/type-checks/tests on
+  Python 3.8–3.11. **Python 3.11 is installed** for this reason. Force tox to use it via basepython
+  overrides:
+  - Lint:  `tox -e lint -x testenv:lint.basepython=python3.11`
+  - Mypy:  `tox -e mypy -x testenv:mypy.basepython=python3.11`
+  - Tests: `tox -e py -x testenv:py.basepython=python3.11`
+- Tests/mypy also run fine directly on Python 3.12 (`python3 -m pytest --doctest-modules tests`);
+  **only flake8 requires 3.11**. `tox` defaults `basepython` to the interpreter it runs under
+  (3.12), so the overrides above are needed to match CI.
+- The `examples/` scripts hit the **real** Resend API and require `RESEND_API_KEY` (and optionally
+  `RESEND_API_URL` to point at a different base URL). They are not needed for tests/lint/build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Resend Python SDK in Cursor Cloud and documents the non-obvious caveats for future agents.

This is a client library (published as `resend`) — there is no server/database/service. The only "app" flow is using the SDK to talk to the Resend REST API, which the test suite mocks.

### What was done
- Installed runtime deps (`requirements.txt`), the package (`pip install -e .`), and the dev/test toolchain (`tox`, `pytest`, `pytest-cov`, `pytest-asyncio`, `httpx`, `mypy`, `types-requests`).
- Installed **Python 3.11** because the pinned `flake8<5.0.0` (see `tox.ini`) is incompatible with the system default Python 3.12 (CI only runs on 3.8–3.11).
- Added `AGENTS.md` with `## Cursor Cloud specific instructions` capturing the durable gotchas (python3 vs python, the flake8/3.12 issue and the basepython overrides, example scripts needing `RESEND_API_KEY`).

### Verification
- `tox -e py -x testenv:py.basepython=python3.11` → 479 passed
- `tox -e lint -x testenv:lint.basepython=python3.11` → OK
- `tox -e mypy -x testenv:mypy.basepython=python3.11` → Success, no issues in 159 files
- End-to-end SDK `Emails.send` + `Emails.get` against a local server emulating the Resend API (exercises the real `RequestsClient` HTTP path).

### Update script (runs on VM startup)
```
pip install -r requirements.txt
pip install -e .
pip install tox pytest pytest-cov pytest-asyncio "httpx>=0.24.0" mypy types-requests
```

Note: only `AGENTS.md` is added; no source code was modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cc6ab62-0578-4642-8dc2-0533a8d44a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cc6ab62-0578-4642-8dc2-0533a8d44a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AGENTS.md with Cursor Cloud dev setup for the `resend` Python SDK, so contributors can run tests, lint, and type checks reliably.
Documents the Python 3.11 requirement for `flake8<5.0.0`, using `python3`, `tox` basepython overrides, and that examples require `RESEND_API_KEY`; no source code changes.

<sup>Written for commit fc6631d27c55ecc84f64270203a1833236530ea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

