### PR TITLE
chore: bump version to 2.34.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.33.0"
+__version__ = "2.34.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump `__version__` to 2.34.0.

Minor release covering #242 (`Webhooks.verify` now returns the parsed `WebhookEventPayload`, new webhook event TypedDicts including `data.message_id` on outbound events, and `EmailBounce.diagnosticCode`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `__version__` to 2.34.0 to publish a minor release with webhook typing and verify improvements.

- **New Features**
  - `Webhooks.verify` now returns a parsed `WebhookEventPayload`.
  - Added TypedDicts for webhook events; outbound events include `data.message_id`.
  - Added `EmailBounce.diagnosticCode`.

<sup>Written for commit 5e35d1d9c49c9aea6bc3da2696c9cbc12d6e1bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

