### PR TITLE
chore: bump version to 2.35.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.34.0"
+__version__ = "2.35.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump `__version__` to 2.35.0. Minor release covering #246 (add suppressions endpoints), plus #238 (preserve HTTP status for API errors) and #244 (chore deps).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `__version__` to 2.35.0 to release suppressions endpoints (#246), preserve HTTP status codes for API errors (#238), and update dependencies (#244).

<sup>Written for commit ec8fb79b4a3d33059836912eb0c830fb4fe522b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

