### PR TITLE
feat: add Broadcasts.cancel() and cancel_async()

### DIFF
--- a/resend/broadcasts/_broadcasts.py
+++ b/resend/broadcasts/_broadcasts.py
@@ -238,6 +238,24 @@ class Broadcasts:
         Whether there are more results available for pagination
         """
 
+    class CancelResponse(BaseResponse):
+        """
+        CancelResponse is the class that wraps the response of the cancel method.
+
+        Attributes:
+            object (str): object type: "broadcast"
+            id (str): id of the canceled broadcast
+        """
+
+        object: str
+        """
+        object type: "broadcast"
+        """
+        id: str
+        """
+        id of the canceled broadcast
+        """
+
     class RemoveResponse(BaseResponse):
         """
         RemoveResponse is the class that wraps the response of the remove method.
@@ -361,6 +379,24 @@ class Broadcasts:
         return resp
 
     @classmethod
+    def cancel(cls, id: str) -> CancelResponse:
+        """
+        Cancel a queued or scheduled broadcast.
+        see more: https://resend.com/docs/api-reference/broadcasts/cancel-broadcast
+
+        Args:
+            id (str): The broadcast ID
+
+        Returns:
+            CancelResponse: The cancel response object
+        """
+        path = f"/broadcasts/{id}/cancel"
+        resp = request.Request[Broadcasts.CancelResponse](
+            path=path, params={}, verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
     def remove(cls, id: str) -> RemoveResponse:
         """
         Delete a single broadcast.
@@ -467,6 +503,24 @@ class Broadcasts:
         path = f"/broadcasts/{id}"
         resp = await AsyncRequest[Broadcast](
             path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def cancel_async(cls, id: str) -> CancelResponse:
+        """
+        Cancel a queued or scheduled broadcast (async).
+        see more: https://resend.com/docs/api-reference/broadcasts/cancel-broadcast
+
+        Args:
+            id (str): The broadcast ID
+
+        Returns:
+            CancelResponse: The cancel response object
+        """
+        path = f"/broadcasts/{id}/cancel"
+        resp = await AsyncRequest[Broadcasts.CancelResponse](
+            path=path, params={}, verb="post"
         ).perform_with_content()
         return resp
 

--- a/tests/broadcasts_async_test.py
+++ b/tests/broadcasts_async_test.py
@@ -139,6 +139,15 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         assert canceled["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
         assert canceled["object"] == "broadcast"
 
+    async def test_should_cancel_broadcasts_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with pytest.raises(NoContentError):
+            _ = await resend.Broadcasts.cancel_async(
+                "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+            )
+
     async def test_broadcasts_remove_async(self) -> None:
         self.set_mock_json(
             {

--- a/tests/broadcasts_async_test.py
+++ b/tests/broadcasts_async_test.py
@@ -125,6 +125,20 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         with pytest.raises(NoContentError):
             _ = await resend.Broadcasts.send_async(params)
 
+    async def test_broadcasts_cancel_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "broadcast",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            }
+        )
+
+        canceled = await resend.Broadcasts.cancel_async(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        )
+        assert canceled["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert canceled["object"] == "broadcast"
+
     async def test_broadcasts_remove_async(self) -> None:
         self.set_mock_json(
             {

--- a/tests/broadcasts_test.py
+++ b/tests/broadcasts_test.py
@@ -101,6 +101,18 @@ class TestResendBroadcasts(ResendBaseTest):
         broadcast: resend.Broadcasts.CreateResponse = resend.Broadcasts.create(params)
         assert broadcast["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
 
+    def test_broadcasts_cancel(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "broadcast",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            }
+        )
+
+        canceled = resend.Broadcasts.cancel("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+        assert canceled["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert canceled["object"] == "broadcast"
+
     def test_broadcasts_remove(self) -> None:
         self.set_mock_json(
             {


### PR DESCRIPTION
## Summary
- Adds `Broadcasts.cancel(id)` / `cancel_async(id)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast.
- Mirrors `Emails.cancel()`'s shape (empty params, id-only).
- Adds `Broadcasts.CancelResponse` (object + id).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135.

## Test plan
- [x] `pytest tests/broadcasts_test.py tests/broadcasts_async_test.py` — 24/24 passing
- [x] `mypy resend/broadcasts/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cancel support for broadcasts via `Broadcasts.cancel(id)` and `cancel_async(id)` to stop queued or scheduled sends with `POST /broadcasts/:id/cancel`, matching `Emails.cancel()`.

- New Features
  - `Broadcasts.cancel(id)` and `cancel_async(id)` to cancel queued/scheduled broadcasts.
  - `Broadcasts.CancelResponse` returning `object` and `id`.

- Bug Fixes
  - Added test to ensure `cancel_async` raises `NoContentError` on no-content responses.

<sup>Written for commit 7298f85fd928329e0ca7bed64244891583373117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

