### PR TITLE
chore: bump version to 2.36.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.35.0"
+__version__ = "2.36.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump `__version__` to 2.36.0. Minor release covering #250 (Broadcasts.cancel() / cancel_async()).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `__version__` to 2.36.0 to release Broadcasts cancellation APIs (`Broadcasts.cancel()` and `cancel_async()`).

<sup>Written for commit 4d8fc8ee690e00c33bf5093fa7422a44880d5c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

