### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/resend/automations/_automations.py
+++ b/resend/automations/_automations.py
@@ -169,6 +169,24 @@ class Automations:
         Whether the automation was successfully deleted.
         """
 
+    class DuplicateResponse(BaseResponse):
+        """
+        DuplicateResponse is the class that wraps the response of the duplicate method.
+
+        Attributes:
+            object (str): The object type, always "automation"
+            id (str): The ID of the newly created automation
+        """
+
+        object: str
+        """
+        The object type, always "automation".
+        """
+        id: str
+        """
+        The ID of the newly created automation.
+        """
+
     class StopResponse(BaseResponse):
         """
         StopResponse is the class that wraps the response of the stop method.
@@ -444,6 +462,24 @@ class Automations:
         return resp
 
     @classmethod
+    def duplicate(cls, automation_id: str) -> "Automations.DuplicateResponse":
+        """
+        Duplicate an automation.
+        see more: https://resend.com/docs/api-reference/automations/duplicate-automation
+
+        Args:
+            automation_id (str): The automation ID
+
+        Returns:
+            DuplicateResponse: The duplicate response
+        """
+        path = f"/automations/{automation_id}/duplicate"
+        resp = request.Request[Automations.DuplicateResponse](
+            path=path, params={}, verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
     def stop(cls, automation_id: str) -> "Automations.StopResponse":
         """
         Stop all active runs of an automation.
@@ -561,6 +597,26 @@ class Automations:
         path = f"/automations/{automation_id}"
         resp = await AsyncRequest[Automations.DeleteResponse](
             path=path, params={}, verb="delete"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def duplicate_async(
+        cls, automation_id: str
+    ) -> "Automations.DuplicateResponse":
+        """
+        Duplicate an automation (async).
+        see more: https://resend.com/docs/api-reference/automations/duplicate-automation
+
+        Args:
+            automation_id (str): The automation ID
+
+        Returns:
+            DuplicateResponse: The duplicate response
+        """
+        path = f"/automations/{automation_id}/duplicate"
+        resp = await AsyncRequest[Automations.DuplicateResponse](
+            path=path, params={}, verb="post"
         ).perform_with_content()
         return resp
 

--- a/tests/automations_async_test.py
+++ b/tests/automations_async_test.py
@@ -123,6 +123,27 @@ class TestResendAutomationsAsync(AsyncResendBaseTest):
                 "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
             )
 
+    async def test_automations_duplicate_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "automation",
+                "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            }
+        )
+
+        resp = await resend.Automations.duplicate_async(
+            "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+        )
+        assert resp["object"] == "automation"
+        assert resp["id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
+
+    async def test_automations_duplicate_async_raises_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with pytest.raises(NoContentError):
+            _ = await resend.Automations.duplicate_async(
+                "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+            )
+
     async def test_automations_stop_async(self) -> None:
         self.set_mock_json(
             {

--- a/tests/automations_test.py
+++ b/tests/automations_test.py
@@ -135,6 +135,18 @@ class TestResendAutomations(ResendBaseTest):
         assert resp["id"] == "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
         assert resp["deleted"] is True
 
+    def test_automations_duplicate(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "automation",
+                "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            }
+        )
+
+        resp = resend.Automations.duplicate("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+        assert resp["object"] == "automation"
+        assert resp["id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
+
     def test_automations_stop(self) -> None:
         self.set_mock_json(
             {


### PR DESCRIPTION
Adds `resend.Automations.duplicate(automation_id)` and `duplicate_async(automation_id)` for `POST /automations/{id}/duplicate`.

Resolves DEV-1708. Mirrors the existing `stop`/`stop_async` pattern and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.Automations.duplicate()` and `duplicate_async()` to clone an automation via `POST /automations/{id}/duplicate`. Previously the SDK had no duplication method; now both sync and async clients can duplicate by ID without breaking existing behavior.

**Review notes**
- Adds `Automations.DuplicateResponse` with `object` and `id` for the new automation.
- Implements `resend.Automations.duplicate(automation_id)` and `resend.Automations.duplicate_async(automation_id)` using a POST to `/automations/{id}/duplicate`, mirroring the existing `stop`/`stop_async` pattern.
- Tests cover sync and async success paths and raise `NoContentError` when the API returns no body, consistent with existing error handling.
- Supports Linear DEV-1708 by exposing duplication in the Python SDK for Devtools usage.

<sup>Written for commit fa2baed43c3f7cfde5257348573c5655e96d48fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

