### PR TITLE
fix(contacts): properties response shape

### DIFF
--- a/examples/contacts_global.py
+++ b/examples/contacts_global.py
@@ -48,7 +48,8 @@ cont_by_id: resend.Contact = resend.Contacts.get(id=contact["id"])
 print("Retrieved contact by ID:")
 print(cont_by_id)
 if "properties" in cont_by_id:
-    print(f"Custom properties: {cont_by_id['properties']}")
+    for name, prop in cont_by_id["properties"].items():
+        print(f"Custom property {name}: {prop['value']} ({prop['type']})")
 
 # List all global contacts
 print("\n--- Listing all global contacts ---")

--- a/resend/contacts/_contact.py
+++ b/resend/contacts/_contact.py
@@ -1,6 +1,17 @@
-from typing import Any, Dict
+from typing import Dict, Union
 
 from typing_extensions import NotRequired, TypedDict
+
+
+class ContactPropertyValue(TypedDict):
+    value: Union[str, int, float, bool]
+    """
+    The property value, a string, number, or boolean depending on type.
+    """
+    type: str
+    """
+    The property type ("string", "number", or "boolean").
+    """
 
 
 class Contact(TypedDict):
@@ -28,7 +39,7 @@ class Contact(TypedDict):
     """
     The unsubscribed status of the contact.
     """
-    properties: NotRequired[Dict[str, Any]]
+    properties: NotRequired[Dict[str, ContactPropertyValue]]
     """
     Custom properties for the contact. Only available for global contacts.
     """

--- a/tests/contacts_test.py
+++ b/tests/contacts_test.py
@@ -377,14 +377,16 @@ class TestResendContacts(ResendBaseTest):
                 "last_name": "Contact",
                 "created_at": "2023-10-06 23:47:56.678+00",
                 "unsubscribed": False,
-                "properties": {"tier": "premium"},
+                "properties": {"tier": {"value": "premium", "type": "string"}},
             }
         )
 
         contact: resend.Contact = resend.Contacts.get(id="global-contact-123")
         assert contact["id"] == "global-contact-123"
         assert contact["email"] == "global@example.com"
-        assert contact.get("properties") == {"tier": "premium"}
+        assert contact.get("properties") == {
+            "tier": {"value": "premium", "type": "string"}
+        }
 
     def test_contacts_list_global(self) -> None:
         self.set_mock_json(
@@ -399,7 +401,6 @@ class TestResendContacts(ResendBaseTest):
                         "last_name": "One",
                         "created_at": "2023-10-06 23:47:56.678+00",
                         "unsubscribed": False,
-                        "properties": {"tier": "free"},
                     },
                     {
                         "id": "global-2",
@@ -408,7 +409,6 @@ class TestResendContacts(ResendBaseTest):
                         "last_name": "Two",
                         "created_at": "2023-10-07 23:47:56.678+00",
                         "unsubscribed": False,
-                        "properties": {"tier": "premium"},
                     },
                 ],
             }


### PR DESCRIPTION
`GET /contacts/:id` returns `properties` where each entry is a `{value, type}` object, not a flat key→string map — the previous `Dict[str, Any]` typing didn't express that. Adds a `ContactPropertyValue` TypedDict (`value`: string, number, or boolean; `type`), updates the get-contact test and example to the real shape, and removes `properties` from the list-response fixtures since only the retrieve endpoint returns it. Create/update request params stay flat maps.

Matches resend-node's `get-contact.interface.ts` and resend-rust's `ContactPropertyResponse`.

docs: https://resend.com/docs/api-reference/contacts/get-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the `properties` response shape for `GET /contacts/:id` to map each property name to an object with `value` and `type` instead of a flat string map, aligning with the API and preventing misuse. Matches `resend-node` and `resend-rust`.

- Introduces `ContactPropertyValue` (`value`: string/number/boolean; `type`: "string" | "number" | "boolean") and updates `Contact.properties` to `Dict[str, ContactPropertyValue]`.
- Updates the example to print `name -> value (type)` and adjusts tests; removes `properties` from list-response fixtures since only the retrieve endpoint returns it.
- No request parameter changes; create/update property payloads remain flat maps. No runtime client behavior changes.

**Migration**
- If you accessed properties as flat strings, update usages to read `contact["properties"][name]["value"]` and, if needed, `["type"]`.
- Update type annotations to reflect `Dict[str, ContactPropertyValue]` for `properties`.

<sup>Written for commit 2857bdf7df895b9b0530ee3bf7f766bba58f55e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

