### PR TITLE
fix: allow null contact first_name and last_name

### DIFF
--- a/resend/contacts/_contact.py
+++ b/resend/contacts/_contact.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -23,13 +23,13 @@ class Contact(TypedDict):
     """
     The email of the contact.
     """
-    first_name: NotRequired[str]
+    first_name: Optional[str]
     """
-    The first name of the contact.
+    The first name of the contact. None when the contact has no first name.
     """
-    last_name: NotRequired[str]
+    last_name: Optional[str]
     """
-    The last name of the contact.
+    The last name of the contact. None when the contact has no last name.
     """
     created_at: str
     """

--- a/resend/webhooks/_webhook_event.py
+++ b/resend/webhooks/_webhook_event.py
@@ -277,13 +277,13 @@ class ContactEventData(TypedDict):
     """
     Whether the contact is unsubscribed.
     """
-    first_name: NotRequired[str]
+    first_name: NotRequired[Optional[str]]
     """
-    The contact's first name.
+    The contact's first name. None when the contact has no first name.
     """
-    last_name: NotRequired[str]
+    last_name: NotRequired[Optional[str]]
     """
-    The contact's last name.
+    The contact's last name. None when the contact has no last name.
     """
 
 


### PR DESCRIPTION
The API returns `null` for a contact with no name, but both fields were typed `NotRequired[str]`. That is the wrong axis: `NotRequired` says the *key* may be absent, while still promising that if the key is there the value is a real `str`. `null` is precisely the case it ruled out, so a type checker would bless `contact["first_name"].upper()` on a value that is `None` at runtime.

resend-node's recorded live responses carry `"first_name":null` in 12 separate fixtures, so this is the normal shape for a contact with no name, not an edge case.

## The two types differ on purpose

**`Contact`** (retrieve and list) → `Optional[str]`. The key is always present in real responses, carrying `null` when there is no name.

**`ContactEventData`** (webhook) → `NotRequired[Optional[str]]`. Here the key really can be missing. The `contact.created` fixture in resend-dotnet omits `first_name` and `last_name` from `data` entirely, and the OpenAPI schema's `required` list agrees, covering only `id`, `created_at`, `updated_at`, `email`, and `unsubscribed`. So the webhook needs both "may be absent" and "may be null", while the REST types only need the latter.

`Optional[str]` is already the convention here for nullable response fields, matching `ApiKey.last_used_at` and the `DomainClaim` fields.

Request types (`CreateParams`, `UpdateParams`) are untouched, since those are inputs.

## Verification

mypy is clean on both changed files. The only errors it reports are the pre-existing missing stubs for `httpx` and `requests`, which are unrelated.

No test added. These are `TypedDict`s with no runtime validation, so a test here could only assert that `json.loads` returns `None` for `null`, which restates the language rather than the contract. Happy to add one if you would rather have the documentation value.

## Related

Spec fix in resend/resend-openapi#91, which makes the same correction to `GetContactResponseSuccess`, `ListContactsResponseSuccess`, and `ContactEventData`.

Ref DEV-1625

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow null contact first_name and last_name in response and webhook types to match API behavior and address DEV-1625. Previously the types allowed missing keys but not nulls; now REST `Contact` uses `Optional[str]` and webhook `ContactEventData` uses `NotRequired[Optional[str]]`.

- Migration: Treat `Contact.first_name`/`last_name` as optional and possibly `None`; in webhooks these keys may be absent and, if present, may be `None`. No changes to request params or runtime behavior.

<sup>Written for commit 5bb8baa3f3fe593ce958deddf4b4f16bfb85f604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Version bump

Includes a patch bump to `2.36.1` in `resend/version.py`. This repo normally bumps in a separate `chore:` PR, so drop that commit if you would rather keep the split.
