### PR TITLE
chore: bump to 2.37.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.36.0"
+__version__ = "2.37.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the `resend` package version constant from 2.36.0 to 2.37.0 to prepare the 2.37.0 release and ensure reported/versioned artifacts are accurate. No runtime behavior changes.

<sup>Written for commit 991627c9665b4581b68d5ee83884e9640ae0cc54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

