### PR TITLE
feat: add Emails.share() and share_async()

### DIFF
--- a/resend/emails/_emails.py
+++ b/resend/emails/_emails.py
@@ -71,6 +71,30 @@ class _CancelScheduledEmailResponse(BaseResponse):
     """
 
 
+class _ShareParams(TypedDict):
+    expires_in: NotRequired[str]
+    """
+    A human-readable duration for how long the share link stays valid
+    (e.g. "10m", "2 hours", "1 day", "1h 30m"). Defaults to "48h".
+    Capped at 48 hours.
+    """
+
+
+class _ShareEmailResponse(BaseResponse):
+    object: str
+    """
+    The object type: email
+    """
+    id: str
+    """
+    The ID of the email that was shared.
+    """
+    url: str
+    """
+    The shareable link URL.
+    """
+
+
 # SendParamsFrom is declared with functional TypedDict syntax here because
 # "from" is a reserved keyword in Python, and this is the best way to
 # support type-checking for it.
@@ -154,6 +178,26 @@ class Emails:
         Attributes:
             object (str): The object type
             id (str): The ID of the updated email.
+        """
+
+    class ShareParams(_ShareParams):
+        """
+        ShareParams is the class that wraps the parameters for the share method.
+
+        Attributes:
+            expires_in (NotRequired[str]): A human-readable duration for how long \
+            the share link stays valid (e.g. "10m", "2 hours", "1 day", "1h 30m"). \
+            Defaults to "48h". Capped at 48 hours.
+        """
+
+    class ShareEmailResponse(_ShareEmailResponse):
+        """
+        ShareEmailResponse is the type that wraps the response of a shared email link.
+
+        Attributes:
+            object (str): The object type
+            id (str): The ID of the email that was shared.
+            url (str): The shareable link URL.
         """
 
     class UpdateParams(_UpdateParams):
@@ -347,6 +391,29 @@ class Emails:
         return resp
 
     @classmethod
+    def share(
+        cls, email_id: str, params: Optional[ShareParams] = None
+    ) -> ShareEmailResponse:
+        """
+        Create a shareable link for an email.
+        see more: https://resend.com/docs/api-reference/emails/share-email
+
+        Args:
+            email_id (str): The ID of the email (sent or received) to share
+            params (Optional[ShareParams]): The share parameters
+
+        Returns:
+            ShareEmailResponse: The response object that contains the shareable link URL
+        """
+        path = f"/emails/{email_id}/share"
+        resp = request.Request[_ShareEmailResponse](
+            path=path,
+            params=cast(Dict[Any, Any], params) if params else {},
+            verb="post",
+        ).perform_with_content()
+        return resp
+
+    @classmethod
     def list(cls, params: Optional[ListParams] = None) -> ListResponse:
         """
         Retrieve a list of emails.
@@ -471,5 +538,28 @@ class Emails:
             path=path,
             params=cast(Dict[Any, Any], params),
             verb="patch",
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def share_async(
+        cls, email_id: str, params: Optional[ShareParams] = None
+    ) -> ShareEmailResponse:
+        """
+        Create a shareable link for an email (async version).
+        see more: https://resend.com/docs/api-reference/emails/share-email
+
+        Args:
+            email_id (str): The ID of the email (sent or received) to share
+            params (Optional[ShareParams]): The share parameters
+
+        Returns:
+            ShareEmailResponse: The response object that contains the shareable link URL
+        """
+        path = f"/emails/{email_id}/share"
+        resp = await AsyncRequest[_ShareEmailResponse](
+            path=path,
+            params=cast(Dict[Any, Any], params) if params else {},
+            verb="post",
         ).perform_with_content()
         return resp

--- a/tests/emails_test.py
+++ b/tests/emails_test.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import resend
 from resend import EmailsReceiving
-from resend.exceptions import NoContentError
+from resend.exceptions import NoContentError, ResendError, ValidationError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -92,6 +92,82 @@ class TestResendEmail(ResendBaseTest):
             email_id="49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
         )
         assert email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+
+    def test_share_email_default_expires_in(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "email",
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+                "url": "https://resend.com/share/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            }
+        )
+        shared_email: resend.Emails.ShareEmailResponse = resend.Emails.share(
+            email_id="49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        )
+        assert shared_email["object"] == "email"
+        assert shared_email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert (
+            shared_email["url"]
+            == "https://resend.com/share/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        )
+
+    def test_share_email_with_custom_expires_in(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "email",
+                "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+                "url": "https://resend.com/share/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            }
+        )
+        share_params: resend.Emails.ShareParams = {
+            "expires_in": "10m",
+        }
+        shared_email: resend.Emails.ShareEmailResponse = resend.Emails.share(
+            email_id="49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            params=share_params,
+        )
+        assert shared_email["id"] == "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        assert (
+            shared_email["url"]
+            == "https://resend.com/share/49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+        )
+
+    def test_share_email_with_malformed_expires_in_raises_validation_error(
+        self,
+    ) -> None:
+        self.set_mock_json(
+            {
+                "statusCode": 422,
+                "name": "validation_error",
+                "message": "expires_in must not exceed 48 hours",
+            }
+        )
+        share_params: resend.Emails.ShareParams = {
+            "expires_in": "72h",
+        }
+        with self.assertRaises(ValidationError):
+            _ = resend.Emails.share(
+                email_id="49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+                params=share_params,
+            )
+
+    def test_share_email_with_unknown_id_raises_error(self) -> None:
+        self.set_mock_json(
+            {
+                "statusCode": 404,
+                "name": "not_found",
+                "message": "Email not found",
+            }
+        )
+        with self.assertRaises(ResendError):
+            _ = resend.Emails.share(email_id="does-not-exist")
+
+    def test_should_share_email_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with self.assertRaises(NoContentError):
+            _ = resend.Emails.share(
+                email_id="49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            )
 
     def test_email_send_with_attachment(self) -> None:
         self.set_mock_json(


### PR DESCRIPTION
Adds `Emails.share(email_id, params=None)` / `share_async`, calling the new `POST /emails/{id}/share` endpoint that creates a shareable link for a sent or received email. See the spec PR resend/resend-openapi#92.

`params['expires_in']` is an optional human-readable duration (e.g. `10m`, `2 hours`, `1 day`; server defaults to `48h`, capped at 48h).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Emails.share()` and `Emails.share_async()` to create a share link for a sent or received email via `POST /emails/{id}/share`. Previously, emails could not be shared; now clients can request a URL with optional `expires_in` (default 48h, capped at 48h), and invalid durations return a validation error.

- Returns `object`, `id`, and `url` in `ShareEmailResponse`.
- Accepts `ShareParams.expires_in` as a human-readable duration (e.g., "10m", "2 hours"); values over 48h or malformed input raise `ValidationError`.
- Adds tests for default expiry, custom expiry, 404 not found, 422 validation, and no-content error paths.
- See docs: https://resend.com/docs/api-reference/emails/share-email

<sup>Written for commit 4c0e803d0ab5498034793eda3c981a4b068ebb83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
