### PR TITLE
feat: add update/update_async for renaming an api key

### DIFF
--- a/examples/api_keys.py
+++ b/examples/api_keys.py
@@ -16,6 +16,13 @@ created_key: resend.ApiKeys.CreateApiKeyResponse = resend.ApiKeys.create(
 print("Created new api key")
 print(f"Key id: {created_key['id']} and token: {created_key['token']}")
 
+update_params: resend.ApiKeys.UpdateParams = {
+    "api_key_id": created_key["id"],
+    "name": "renamed-example",
+}
+updated_key: resend.ApiKeys.UpdateApiKeyResponse = resend.ApiKeys.update(update_params)
+print(f"Updated api key: {updated_key['id']}")
+
 keys: resend.ApiKeys.ListResponse = resend.ApiKeys.list()
 for key in keys["data"]:
     print(key["id"])

--- a/examples/async/api_keys_async.py
+++ b/examples/async/api_keys_async.py
@@ -19,6 +19,13 @@ async def main() -> None:
     print("Created new api key")
     print(f"Key id: {key['id']} and token: {key['token']}")
 
+    update_params: resend.ApiKeys.UpdateParams = {
+        "api_key_id": key["id"],
+        "name": "renamed-example",
+    }
+    updated_key = await resend.ApiKeys.update_async(update_params)
+    print(f"Updated api key: {updated_key['id']}")
+
     keys: resend.ApiKeys.ListResponse = await resend.ApiKeys.list_async()
     for k in keys["data"]:
         print(k["id"])

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -178,7 +178,7 @@ class ApiKeys:
         api_key_id = params["api_key_id"]
         path = f"/api-keys/{api_key_id}"
         resp = request.Request[ApiKeys.UpdateApiKeyResponse](
-            path=path, params=cast(Dict[Any, Any], params), verb="patch"
+            path=path, params={"name": params["name"]}, verb="patch"
         ).perform_with_content()
         return resp
 
@@ -258,7 +258,7 @@ class ApiKeys:
         api_key_id = params["api_key_id"]
         path = f"/api-keys/{api_key_id}"
         resp = await AsyncRequest[ApiKeys.UpdateApiKeyResponse](
-            path=path, params=cast(Dict[Any, Any], params), verb="patch"
+            path=path, params={"name": params["name"]}, verb="patch"
         ).perform_with_content()
         return resp
 

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -80,6 +80,24 @@ class ApiKeys:
         Whether the API key was deleted
         """
 
+    class UpdateApiKeyResponse(BaseResponse):
+        """
+        UpdateApiKeyResponse is the type that wraps the response of the API key that was updated
+
+        Attributes:
+            object (str): The object type, always "api_key"
+            id (str): The ID of the updated API key
+        """
+
+        object: str
+        """
+        The object type, always "api_key"
+        """
+        id: str
+        """
+        The ID of the updated API key
+        """
+
     class ListParams(TypedDict):
         limit: NotRequired[int]
         """
@@ -115,6 +133,16 @@ class ApiKeys:
         This is only used when the permission is set to sending_access.
         """
 
+    class UpdateParams(TypedDict):
+        api_key_id: str
+        """
+        The API key ID.
+        """
+        name: str
+        """
+        The API key name.
+        """
+
     @classmethod
     def create(cls, params: CreateParams) -> CreateApiKeyResponse:
         """
@@ -130,6 +158,27 @@ class ApiKeys:
         path = "/api-keys"
         resp = request.Request[ApiKeys.CreateApiKeyResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, params: UpdateParams) -> UpdateApiKeyResponse:
+        """
+        Update an existing API key's name.
+        see more: https://resend.com/docs/api-reference/api-keys/update-api-key
+
+        Args:
+            params (UpdateParams): The API key update parameters
+                - api_key_id: The API key ID
+                - name: The new API key name
+
+        Returns:
+            UpdateApiKeyResponse: The updated API key response with id
+        """
+        api_key_id = params["api_key_id"]
+        path = f"/api-keys/{api_key_id}"
+        resp = request.Request[ApiKeys.UpdateApiKeyResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
 
@@ -189,6 +238,27 @@ class ApiKeys:
         path = "/api-keys"
         resp = await AsyncRequest[ApiKeys.CreateApiKeyResponse](
             path=path, params=cast(Dict[Any, Any], params), verb="post"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def update_async(cls, params: UpdateParams) -> UpdateApiKeyResponse:
+        """
+        Update an existing API key's name (async).
+        see more: https://resend.com/docs/api-reference/api-keys/update-api-key
+
+        Args:
+            params (UpdateParams): The API key update parameters
+                - api_key_id: The API key ID
+                - name: The new API key name
+
+        Returns:
+            UpdateApiKeyResponse: The updated API key response with id
+        """
+        api_key_id = params["api_key_id"]
+        path = f"/api-keys/{api_key_id}"
+        resp = await AsyncRequest[ApiKeys.UpdateApiKeyResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
 

--- a/tests/api_keys_async_test.py
+++ b/tests/api_keys_async_test.py
@@ -60,6 +60,35 @@ class TestResendApiKeysAsync(AsyncResendBaseTest):
         with pytest.raises(NoContentError):
             _ = await resend.ApiKeys.list_async()
 
+    async def test_api_keys_update_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "api_key",
+                "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            }
+        )
+
+        params: resend.ApiKeys.UpdateParams = {
+            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "name": "updated-name",
+        }
+        updated_key: resend.ApiKeys.UpdateApiKeyResponse = (
+            await resend.ApiKeys.update_async(params)
+        )
+        assert updated_key["object"] == "api_key"
+        assert updated_key["id"] == "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+
+    async def test_should_update_api_key_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        params: resend.ApiKeys.UpdateParams = {
+            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "name": "updated-name",
+        }
+        with pytest.raises(NoContentError):
+            _ = await resend.ApiKeys.update_async(params)
+
     async def test_api_keys_remove_async(self) -> None:
         self.set_mock_json(
             {

--- a/tests/api_keys_test.py
+++ b/tests/api_keys_test.py
@@ -127,6 +127,31 @@ class TestResendApiKeys(ResendBaseTest):
         assert len(keys["data"]) == 1
         assert keys["data"][0]["id"] == "test-key-3"
 
+    def test_api_keys_update(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "api_key",
+                "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            }
+        )
+
+        params: resend.ApiKeys.UpdateParams = {
+            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "name": "updated-name",
+        }
+        updated_key: resend.ApiKeys.UpdateApiKeyResponse = resend.ApiKeys.update(params)
+        assert updated_key["object"] == "api_key"
+        assert updated_key["id"] == "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+
+    def test_should_update_api_key_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.ApiKeys.UpdateParams = {
+            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "name": "updated-name",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.ApiKeys.update(params)
+
     def test_api_keys_remove(self) -> None:
         self.set_mock_json(
             {


### PR DESCRIPTION
## Summary
- Adds `ApiKeys.update`/`update_async` for the new `PATCH /api-keys/:id` endpoint — see https://resend.com/docs/api-reference/api-keys/update-api-key.
- Only `name` is patchable. `permission`/`domain_id` are deliberately not exposed — the endpoint doesn't accept them (prevents a leaked management key from silently widening another key's scope).
- No client-side length validation on `name`, matching `create`'s existing (lack of) validation.

Draft — SDK rollout in progress, tracked in Linear as DEV-1219.

## Test plan
- [x] `pytest --cov=resend --doctest-modules tests` — 568 passed
- [x] `mypy --ignore-missing-imports resend/ examples/ tests/` — clean
- [x] `black`/`isort`/`flake8` — clean on touched files