### PR TITLE
chore: bump version to 2.38.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.37.0"
+__version__ = "2.38.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump `__version__` to 2.38.0. Minor release covering #258 (add `apiKeys.update`/`update_async` for renaming an API key).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps SDK version to 2.38.0 to ship `apiKeys.update`/`update_async` for renaming an API key.

- Changes `__version__` only; no behavior change in this diff.
- Release includes new client methods for renaming an API key (covers #258).
- No migration required.

<sup>Written for commit 0bc35d641451f175fdbee41338e8a9435243cc6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

