### PR TITLE
chore: bump version to 2.39.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.38.0"
+__version__ = "2.39.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump `__version__` to 2.39.0. Minor release covering #257 (Emails.share()/share_async()).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps version to 2.39.0 to publish the minor release that adds `Emails.share()` and `Emails.share_async()` from #257. Previous version was 2.38.0; this PR only updates the version string and does not change runtime behavior. No migration required.

<sup>Written for commit f21713cfc2b12049a1701ec9001c29adfbd3dfce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

