### PR TITLE
feat: add broadcasts.recipients() method

### DIFF
--- a/examples/async/broadcasts_async.py
+++ b/examples/async/broadcasts_async.py
@@ -57,6 +57,17 @@ async def main() -> None:
     print("retrieved broadcast !\n")
     print(retrieved)
 
+    recipients_params: resend.Broadcasts.RecipientsParams = {
+        "broadcast_id": broadcast["id"],
+        "type": "delivered",
+    }
+    recipients: resend.Broadcasts.RecipientsResponse = (
+        await resend.Broadcasts.recipients_async(recipients_params)
+    )
+    print("Broadcast recipients !\n")
+    print(f"Found {len(recipients['data'])} recipients")
+    print(f"Has more recipients: {recipients['has_more']}")
+
     if retrieved["status"] == "draft":
         removed: resend.Broadcasts.RemoveResponse = (
             await resend.Broadcasts.remove_async(id=broadcast["id"])

--- a/examples/broadcasts.py
+++ b/examples/broadcasts.py
@@ -46,6 +46,17 @@ retrieved: resend.Broadcast = resend.Broadcasts.get(id=broadcast["id"])
 print("retrieved broadcast !\n")
 print(retrieved)
 
+recipients_params: resend.Broadcasts.RecipientsParams = {
+    "broadcast_id": broadcast["id"],
+    "type": "delivered",
+}
+recipients: resend.Broadcasts.RecipientsResponse = resend.Broadcasts.recipients(
+    recipients_params
+)
+print("Broadcast recipients !\n")
+print(f"Found {len(recipients['data'])} recipients")
+print(f"Has more recipients: {recipients['has_more']}")
+
 if retrieved["status"] == "draft":
     removed: resend.Broadcasts.RemoveResponse = resend.Broadcasts.remove(
         id=broadcast["id"]

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -15,6 +15,10 @@ from .automations._automation import (Automation, AutomationConnection,
                                       AutomationStepType)
 from .automations._automations import Automations
 from .broadcasts._broadcast import Broadcast
+from .broadcasts._broadcast_recipient import (BroadcastRecipient,
+                                              BroadcastRecipientBounceType,
+                                              BroadcastRecipientClickedLink,
+                                              BroadcastRecipientEventType)
 from .broadcasts._broadcasts import Broadcasts
 from .broadcasts._clicked_link import ClickedLink
 from .contact_properties._contact_properties import ContactProperties
@@ -161,6 +165,10 @@ __all__ = [
     "Tag",
     "Broadcast",
     "ClickedLink",
+    "BroadcastRecipient",
+    "BroadcastRecipientBounceType",
+    "BroadcastRecipientClickedLink",
+    "BroadcastRecipientEventType",
     "Segment",
     "Suppression",
     "SuppressionListItem",

--- a/resend/broadcasts/_broadcast_recipient.py
+++ b/resend/broadcasts/_broadcast_recipient.py
@@ -1,0 +1,80 @@
+from typing import List, Union
+
+from typing_extensions import Literal, NotRequired, TypedDict
+
+BroadcastRecipientEventType = Literal[
+    "sent",
+    "delivered",
+    "opened",
+    "clicked",
+    "bounced",
+    "complained",
+    "unsubscribed",
+    "suppressed",
+]
+
+BroadcastRecipientBounceType = Literal["permanent", "transient", "undetermined"]
+
+
+class BroadcastRecipientClickedLink(TypedDict):
+    """
+    BroadcastRecipientClickedLink represents a link clicked by a broadcast recipient.
+
+    Attributes:
+        url (str): The clicked URL.
+        clicks (int): The number of times this recipient clicked this URL.
+    """
+
+    url: str
+    """
+    The clicked URL.
+    """
+    clicks: int
+    """
+    The number of times this recipient clicked this URL.
+    """
+
+
+class BroadcastRecipient(TypedDict):
+    """
+    BroadcastRecipient represents a single recipient in a broadcast recipients list.
+
+    Attributes:
+        id (str): Opaque cursor identifying this row, used for pagination.
+        contact_id (Union[str, None]): The ID of the contact associated with this recipient, if one exists.
+        email (str): The recipient's email address.
+        count (NotRequired[int]): The number of times this recipient triggered the event.
+            Only present when the requested type is "opened" or "clicked".
+        bounce_type (NotRequired[BroadcastRecipientBounceType]): The type of bounce.
+            Only present when the requested type is "bounced".
+        clicked_links (NotRequired[List[BroadcastRecipientClickedLink]]): The links this recipient clicked.
+            Only present when the requested type is "clicked".
+    """
+
+    id: str
+    """
+    Opaque cursor identifying this row, used for pagination.
+    """
+    contact_id: Union[str, None]
+    """
+    The ID of the contact associated with this recipient, if one exists.
+    """
+    email: str
+    """
+    The recipient's email address.
+    """
+    count: NotRequired[int]
+    """
+    The number of times this recipient triggered the event.
+    Only present when the requested type is "opened" or "clicked".
+    """
+    bounce_type: NotRequired[BroadcastRecipientBounceType]
+    """
+    The type of bounce.
+    Only present when the requested type is "bounced".
+    """
+    clicked_links: NotRequired[List[BroadcastRecipientClickedLink]]
+    """
+    The links this recipient clicked.
+    Only present when the requested type is "clicked".
+    """

--- a/resend/broadcasts/_broadcasts.py
+++ b/resend/broadcasts/_broadcasts.py
@@ -7,6 +7,9 @@ from resend._base_response import BaseResponse
 from resend.pagination_helper import PaginationHelper
 
 from ._broadcast import Broadcast
+from ._broadcast_recipient import (BroadcastRecipient,
+                                   BroadcastRecipientBounceType,
+                                   BroadcastRecipientEventType)
 from ._clicked_link import ClickedLink
 
 # Async imports (optional - only available with pip install resend[async])
@@ -239,6 +242,77 @@ class Broadcasts:
         Whether there are more results available for pagination
         """
 
+    class RecipientsParams(TypedDict):
+        """RecipientsParams is the class that wraps the parameters for the recipients method.
+
+        Attributes:
+            broadcast_id (str): The ID of the broadcast.
+            type (BroadcastRecipientEventType): The recipient event type to filter by.
+            email (NotRequired[str]): Filter recipients by email address (substring match).
+            bounce_type (NotRequired[BroadcastRecipientBounceType]): Filter bounced recipients
+                by bounce type. Only valid when type is "bounced".
+            limit (NotRequired[int]): Number of recipients to retrieve. Maximum is 100, and minimum is 1.
+            after (NotRequired[str]): The ID after which we'll retrieve more recipients (for pagination).
+            before (NotRequired[str]): The ID before which we'll retrieve more recipients (for pagination).
+        """
+
+        broadcast_id: str
+        """
+        The ID of the broadcast.
+        """
+        type: BroadcastRecipientEventType
+        """
+        The recipient event type to filter by.
+        """
+        email: NotRequired[str]
+        """
+        Filter recipients by email address (substring match).
+        """
+        bounce_type: NotRequired[BroadcastRecipientBounceType]
+        """
+        Filter bounced recipients by bounce type.
+        Only valid when type is "bounced".
+        """
+        limit: NotRequired[int]
+        """
+        Number of recipients to retrieve. Maximum is 100, and minimum is 1.
+        """
+        after: NotRequired[str]
+        """
+        The ID after which we'll retrieve more recipients (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the before parameter.
+        """
+        before: NotRequired[str]
+        """
+        The ID before which we'll retrieve more recipients (for pagination).
+        This ID will not be included in the returned list.
+        Cannot be used with the after parameter.
+        """
+
+    class RecipientsResponse(BaseResponse):
+        """
+        RecipientsResponse is the class that wraps the response of the recipients method with pagination metadata.
+
+        Attributes:
+            object (str): object type, always "list"
+            data (List[BroadcastRecipient]): A list of broadcast recipient objects
+            has_more (bool): Whether there are more results available
+        """
+
+        object: str
+        """
+        object type, always "list"
+        """
+        data: List[BroadcastRecipient]
+        """
+        A list of broadcast recipient objects
+        """
+        has_more: bool
+        """
+        Whether there are more results available for pagination
+        """
+
     class ListClickedLinksParams(TypedDict):
         limit: NotRequired[int]
         """
@@ -421,6 +495,26 @@ class Broadcasts:
         return resp
 
     @classmethod
+    def recipients(cls, params: RecipientsParams) -> RecipientsResponse:
+        """
+        Retrieve a broadcast's recipients for a given event type.
+        see more: https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients
+
+        Args:
+            params (RecipientsParams): The recipients filter and pagination parameters
+
+        Returns:
+            RecipientsResponse: A list of broadcast recipient objects
+        """
+        base_path = f"/broadcasts/{params['broadcast_id']}/recipients"
+        query_params = {k: v for k, v in params.items() if k != "broadcast_id"}
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[Broadcasts.RecipientsResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
     def clicked_links(
         cls, id: str, params: Optional[ListClickedLinksParams] = None
     ) -> ListClickedLinksResponse:
@@ -571,6 +665,26 @@ class Broadcasts:
         """
         path = f"/broadcasts/{id}"
         resp = await AsyncRequest[Broadcast](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def recipients_async(cls, params: RecipientsParams) -> RecipientsResponse:
+        """
+        Retrieve a broadcast's recipients for a given event type (async).
+        see more: https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients
+
+        Args:
+            params (RecipientsParams): The recipients filter and pagination parameters
+
+        Returns:
+            RecipientsResponse: A list of broadcast recipient objects
+        """
+        base_path = f"/broadcasts/{params['broadcast_id']}/recipients"
+        query_params = {k: v for k, v in params.items() if k != "broadcast_id"}
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = await AsyncRequest[Broadcasts.RecipientsResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp

--- a/tests/broadcasts_async_test.py
+++ b/tests/broadcasts_async_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 import resend
-from resend.exceptions import NoContentError
+from resend.exceptions import NoContentError, ResendError
 from tests.conftest import AsyncResendBaseTest
 
 # flake8: noqa
@@ -225,6 +225,152 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         self.set_mock_json(None)
         with pytest.raises(NoContentError):
             _ = await resend.Broadcasts.list_async()
+
+    async def test_broadcasts_recipients_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                        "email": "carter@example.com",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "delivered",
+        }
+        recipients: resend.Broadcasts.RecipientsResponse = (
+            await resend.Broadcasts.recipients_async(params)
+        )
+        assert recipients["object"] == "list"
+        assert recipients["has_more"] is False
+        assert len(recipients["data"]) == 1
+
+        recipient = recipients["data"][0]
+        assert recipient["id"] == "b2Zmc2V0OjA"
+        assert recipient["contact_id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
+        assert recipient["email"] == "carter@example.com"
+
+    async def test_broadcasts_recipients_async_opened_has_count(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": None,
+                        "email": "carter@example.com",
+                        "count": 3,
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "opened",
+        }
+        recipients = await resend.Broadcasts.recipients_async(params)
+        recipient = recipients["data"][0]
+        assert recipient["contact_id"] is None
+        assert recipient["count"] == 3
+
+    async def test_broadcasts_recipients_async_clicked_has_clicked_links(
+        self,
+    ) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                        "email": "carter@example.com",
+                        "count": 2,
+                        "clicked_links": [
+                            {"url": "https://resend.com/pricing", "clicks": 2}
+                        ],
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "clicked",
+            "email": "carter",
+            "limit": 10,
+        }
+        recipients = await resend.Broadcasts.recipients_async(params)
+        recipient = recipients["data"][0]
+        assert recipient["count"] == 2
+        assert recipient["clicked_links"] == [
+            {"url": "https://resend.com/pricing", "clicks": 2}
+        ]
+
+    async def test_broadcasts_recipients_async_bounced_has_bounce_type(
+        self,
+    ) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": None,
+                        "email": "carter@example.com",
+                        "bounce_type": "permanent",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "bounced",
+            "bounce_type": "permanent",
+        }
+        recipients = await resend.Broadcasts.recipients_async(params)
+        recipient = recipients["data"][0]
+        assert recipient["bounce_type"] == "permanent"
+
+    async def test_broadcasts_recipients_async_raise_exception_when_not_found(
+        self,
+    ) -> None:
+        self.set_mock_json(
+            {
+                "statusCode": 404,
+                "name": "not_found",
+                "message": "Broadcast not found",
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "does-not-exist",
+            "type": "sent",
+        }
+        with pytest.raises(ResendError):
+            _ = await resend.Broadcasts.recipients_async(params)
+
+    async def test_should_recipients_broadcasts_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "sent",
+        }
+        with pytest.raises(NoContentError):
+            _ = await resend.Broadcasts.recipients_async(params)
 
     async def test_broadcasts_clicked_links_async(self) -> None:
         self.set_mock_json(

--- a/tests/broadcasts_test.py
+++ b/tests/broadcasts_test.py
@@ -1,5 +1,5 @@
 import resend
-from resend.exceptions import NoContentError
+from resend.exceptions import NoContentError, ResendError
 from tests.conftest import ResendBaseTest
 
 # flake8: noqa
@@ -241,6 +241,135 @@ class TestResendBroadcasts(ResendBaseTest):
         assert broadcasts["has_more"] is False
         assert len(broadcasts["data"]) == 1
         assert broadcasts["data"][0]["id"] == "broadcast-3"
+
+    def test_broadcasts_recipients(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                        "email": "carter@example.com",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "delivered",
+        }
+        recipients: resend.Broadcasts.RecipientsResponse = resend.Broadcasts.recipients(
+            params
+        )
+        assert recipients["object"] == "list"
+        assert recipients["has_more"] is False
+        assert len(recipients["data"]) == 1
+
+        recipient = recipients["data"][0]
+        assert recipient["id"] == "b2Zmc2V0OjA"
+        assert recipient["contact_id"] == "e169aa45-1ecf-4183-9955-b1499d5701d3"
+        assert recipient["email"] == "carter@example.com"
+
+    def test_broadcasts_recipients_opened_has_count(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": None,
+                        "email": "carter@example.com",
+                        "count": 3,
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "opened",
+        }
+        recipients = resend.Broadcasts.recipients(params)
+        recipient = recipients["data"][0]
+        assert recipient["contact_id"] is None
+        assert recipient["count"] == 3
+
+    def test_broadcasts_recipients_clicked_has_clicked_links(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+                        "email": "carter@example.com",
+                        "count": 2,
+                        "clicked_links": [
+                            {"url": "https://resend.com/pricing", "clicks": 2}
+                        ],
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "clicked",
+            "email": "carter",
+            "limit": 10,
+        }
+        recipients = resend.Broadcasts.recipients(params)
+        recipient = recipients["data"][0]
+        assert recipient["count"] == 2
+        assert recipient["clicked_links"] == [
+            {"url": "https://resend.com/pricing", "clicks": 2}
+        ]
+
+    def test_broadcasts_recipients_bounced_has_bounce_type(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "contact_id": None,
+                        "email": "carter@example.com",
+                        "bounce_type": "permanent",
+                    }
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "type": "bounced",
+            "bounce_type": "permanent",
+        }
+        recipients = resend.Broadcasts.recipients(params)
+        recipient = recipients["data"][0]
+        assert recipient["bounce_type"] == "permanent"
+
+    def test_broadcasts_recipients_raise_exception_when_not_found(self) -> None:
+        self.set_mock_json(
+            {
+                "statusCode": 404,
+                "name": "not_found",
+                "message": "Broadcast not found",
+            }
+        )
+
+        params: resend.Broadcasts.RecipientsParams = {
+            "broadcast_id": "does-not-exist",
+            "type": "sent",
+        }
+        with self.assertRaises(ResendError):
+            _ = resend.Broadcasts.recipients(params)
 
     def test_broadcasts_clicked_links(self) -> None:
         self.set_mock_json(


### PR DESCRIPTION
Adds `Broadcasts.recipients()` / `recipients_async()` for `GET /broadcasts/{id}/recipients`.

Spec: https://github.com/resend/resend-openapi/pull/97
Node reference: https://github.com/resend/resend-node/pull/1078

Tests: 584 passed. flake8 + mypy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.Broadcasts.recipients()` and `resend.Broadcasts.recipients_async()` to list a broadcast’s recipients by event type with filters and cursor pagination. Previously recipient-level delivery and engagement data was not available; now clients can query sent, delivered, opened, clicked, bounced, and more, with counts and clicked links when applicable.

- Public API: exports `RecipientsParams`, `RecipientsResponse`, `BroadcastRecipient`, `BroadcastRecipientEventType`, `BroadcastRecipientBounceType`, and `BroadcastRecipientClickedLink` via `resend.__init__`.
- Request: requires `broadcast_id` (path) and `type`; optional `email`, `bounce_type` (only with `type="bounced"`), `limit` (1–100), and cursor params `after`/`before` (mutually exclusive).
- Response: returns `object="list"`, `data: List[BroadcastRecipient]`, `has_more`; optional `count` for `opened`/`clicked`, `bounce_type` for `bounced`, and `clicked_links` for `clicked`.
- Errors and examples: raises `ResendError` on 404 and `NoContentError` on empty responses; adds sync/async examples and tests covering success, pagination, optional fields, and error cases.

<sup>Written for commit 7a29780c0ea2a8d1118ce9f5b52ade875cad6167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

