### PR TITLE
feat: add broadcasts.clicked_links() method

### DIFF
--- a/examples/broadcasts.py
+++ b/examples/broadcasts.py
@@ -74,3 +74,12 @@ if list_response["data"]:
     print(f"Has more broadcasts: {paginated_broadcasts['has_more']}")
 else:
     print("No broadcasts available for pagination example")
+
+print("\n--- Clicked links ---")
+clicked_links: resend.Broadcasts.ListClickedLinksResponse = (
+    resend.Broadcasts.clicked_links(id=broadcast["id"])
+)
+print(f"Found {len(clicked_links['data'])} clicked links")
+print(f"Has more clicked links: {clicked_links['has_more']}")
+for link in clicked_links["data"]:
+    print(f"{link['url']}: {link['clicks']} clicks, {link['unique_clicks']} unique")

--- a/resend/__init__.py
+++ b/resend/__init__.py
@@ -16,6 +16,7 @@ from .automations._automation import (Automation, AutomationConnection,
 from .automations._automations import Automations
 from .broadcasts._broadcast import Broadcast
 from .broadcasts._broadcasts import Broadcasts
+from .broadcasts._clicked_link import ClickedLink
 from .contact_properties._contact_properties import ContactProperties
 from .contact_properties._contact_property import ContactProperty
 from .contacts._contact import Contact
@@ -159,6 +160,7 @@ __all__ = [
     "EmailTemplate",
     "Tag",
     "Broadcast",
+    "ClickedLink",
     "Segment",
     "Suppression",
     "SuppressionListItem",

--- a/resend/broadcasts/_broadcasts.py
+++ b/resend/broadcasts/_broadcasts.py
@@ -7,6 +7,7 @@ from resend._base_response import BaseResponse
 from resend.pagination_helper import PaginationHelper
 
 from ._broadcast import Broadcast
+from ._clicked_link import ClickedLink
 
 # Async imports (optional - only available with pip install resend[async])
 try:
@@ -238,6 +239,47 @@ class Broadcasts:
         Whether there are more results available for pagination
         """
 
+    class ListClickedLinksParams(TypedDict):
+        limit: NotRequired[int]
+        """
+        Number of clicked links to retrieve. Maximum is 100, and minimum is 1.
+        """
+        after: NotRequired[str]
+        """
+        The cursor after which we'll retrieve more clicked links (for pagination).
+        This cursor will not be included in the returned list.
+        Cannot be used with the before parameter.
+        """
+        before: NotRequired[str]
+        """
+        The cursor before which we'll retrieve more clicked links (for pagination).
+        This cursor will not be included in the returned list.
+        Cannot be used with the after parameter.
+        """
+
+    class ListClickedLinksResponse(BaseResponse):
+        """
+        ListClickedLinksResponse is the class that wraps the response of the clicked_links method with pagination metadata.
+
+        Attributes:
+            object (str): object type, always "list"
+            data (List[ClickedLink]): A list of clicked link objects
+            has_more (bool): Whether there are more results available
+        """
+
+        object: str
+        """
+        object type, always "list"
+        """
+        data: List[ClickedLink]
+        """
+        A list of clicked link objects
+        """
+        has_more: bool
+        """
+        Whether there are more results available for pagination
+        """
+
     class CancelResponse(BaseResponse):
         """
         CancelResponse is the class that wraps the response of the cancel method.
@@ -379,6 +421,33 @@ class Broadcasts:
         return resp
 
     @classmethod
+    def clicked_links(
+        cls, id: str, params: Optional[ListClickedLinksParams] = None
+    ) -> ListClickedLinksResponse:
+        """
+        Retrieve a broadcast's clicked links.
+        see more: https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links
+
+        Args:
+            id (str): The broadcast ID
+            params (Optional[ListClickedLinksParams]): Optional pagination parameters
+                - limit: Number of clicked links to retrieve (max 100, min 1).
+                  If not provided, all clicked links will be returned without pagination.
+                - after: cursor after which to retrieve more clicked links
+                - before: cursor before which to retrieve more clicked links
+
+        Returns:
+            ListClickedLinksResponse: A list of clicked link objects
+        """
+        base_path = f"/broadcasts/{id}/clicked-links"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = request.Request[Broadcasts.ListClickedLinksResponse](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
     def cancel(cls, id: str) -> CancelResponse:
         """
         Cancel a queued or scheduled broadcast.
@@ -502,6 +571,29 @@ class Broadcasts:
         """
         path = f"/broadcasts/{id}"
         resp = await AsyncRequest[Broadcast](
+            path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def clicked_links_async(
+        cls, id: str, params: Optional[ListClickedLinksParams] = None
+    ) -> ListClickedLinksResponse:
+        """
+        Retrieve a broadcast's clicked links (async).
+        see more: https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links
+
+        Args:
+            id (str): The broadcast ID
+            params (Optional[ListClickedLinksParams]): Optional pagination parameters
+
+        Returns:
+            ListClickedLinksResponse: A list of clicked link objects
+        """
+        base_path = f"/broadcasts/{id}/clicked-links"
+        query_params = cast(Dict[Any, Any], params) if params else None
+        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        resp = await AsyncRequest[Broadcasts.ListClickedLinksResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
         return resp

--- a/resend/broadcasts/_clicked_link.py
+++ b/resend/broadcasts/_clicked_link.py
@@ -1,0 +1,21 @@
+from typing_extensions import TypedDict
+
+
+class ClickedLink(TypedDict):
+    id: str
+    """
+    An opaque cursor for this row, used only for pagination.
+    It does not identify any entity in Resend.
+    """
+    url: str
+    """
+    The URL that was clicked.
+    """
+    clicks: int
+    """
+    Total number of clicks on this URL.
+    """
+    unique_clicks: int
+    """
+    Number of unique clicks on this URL.
+    """

--- a/tests/broadcasts_async_test.py
+++ b/tests/broadcasts_async_test.py
@@ -225,3 +225,55 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         self.set_mock_json(None)
         with pytest.raises(NoContentError):
             _ = await resend.Broadcasts.list_async()
+
+    async def test_broadcasts_clicked_links_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "url": "https://resend.com/pricing",
+                        "clicks": 42,
+                        "unique_clicks": 30,
+                    },
+                    {
+                        "id": "b2Zmc2V0OjE",
+                        "url": "https://resend.com/docs",
+                        "clicks": 17,
+                        "unique_clicks": 15,
+                    },
+                ],
+            }
+        )
+
+        clicked_links: resend.Broadcasts.ListClickedLinksResponse = (
+            await resend.Broadcasts.clicked_links_async(
+                "559ac32e-9ef5-46fb-82a1-b76b840c0f7b"
+            )
+        )
+        assert clicked_links["object"] == "list"
+        assert clicked_links["has_more"] is False
+        assert len(clicked_links["data"]) == 2
+
+        link = clicked_links["data"][0]
+        assert link["id"] == "b2Zmc2V0OjA"
+        assert link["url"] == "https://resend.com/pricing"
+        assert link["clicks"] == 42
+        assert link["unique_clicks"] == 30
+
+        link = clicked_links["data"][1]
+        assert link["id"] == "b2Zmc2V0OjE"
+        assert link["url"] == "https://resend.com/docs"
+        assert link["clicks"] == 17
+        assert link["unique_clicks"] == 15
+
+    async def test_should_clicked_links_broadcasts_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with pytest.raises(NoContentError):
+            _ = await resend.Broadcasts.clicked_links_async(
+                "559ac32e-9ef5-46fb-82a1-b76b840c0f7b"
+            )

--- a/tests/broadcasts_test.py
+++ b/tests/broadcasts_test.py
@@ -241,3 +241,96 @@ class TestResendBroadcasts(ResendBaseTest):
         assert broadcasts["has_more"] is False
         assert len(broadcasts["data"]) == 1
         assert broadcasts["data"][0]["id"] == "broadcast-3"
+
+    def test_broadcasts_clicked_links(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "url": "https://resend.com/pricing",
+                        "clicks": 42,
+                        "unique_clicks": 30,
+                    },
+                    {
+                        "id": "b2Zmc2V0OjE",
+                        "url": "https://resend.com/docs",
+                        "clicks": 17,
+                        "unique_clicks": 15,
+                    },
+                ],
+            }
+        )
+
+        clicked_links: resend.Broadcasts.ListClickedLinksResponse = (
+            resend.Broadcasts.clicked_links("559ac32e-9ef5-46fb-82a1-b76b840c0f7b")
+        )
+        assert clicked_links["object"] == "list"
+        assert clicked_links["has_more"] is False
+        assert len(clicked_links["data"]) == 2
+
+        link = clicked_links["data"][0]
+        assert link["id"] == "b2Zmc2V0OjA"
+        assert link["url"] == "https://resend.com/pricing"
+        assert link["clicks"] == 42
+        assert link["unique_clicks"] == 30
+
+        link = clicked_links["data"][1]
+        assert link["id"] == "b2Zmc2V0OjE"
+        assert link["url"] == "https://resend.com/docs"
+        assert link["clicks"] == 17
+        assert link["unique_clicks"] == 15
+
+    def test_broadcasts_clicked_links_with_pagination_params(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": True,
+                "data": [
+                    {
+                        "id": "b2Zmc2V0OjA",
+                        "url": "https://resend.com/pricing",
+                        "clicks": 42,
+                        "unique_clicks": 30,
+                    },
+                ],
+            }
+        )
+
+        params: resend.Broadcasts.ListClickedLinksParams = {
+            "limit": 1,
+            "after": "cursor-value",
+        }
+        clicked_links: resend.Broadcasts.ListClickedLinksResponse = (
+            resend.Broadcasts.clicked_links(
+                "559ac32e-9ef5-46fb-82a1-b76b840c0f7b", params=params
+            )
+        )
+        assert clicked_links["object"] == "list"
+        assert clicked_links["has_more"] is True
+        assert len(clicked_links["data"]) == 1
+        assert clicked_links["data"][0]["id"] == "b2Zmc2V0OjA"
+
+    def test_broadcasts_clicked_links_with_before_param(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "list",
+                "has_more": False,
+                "data": [],
+            }
+        )
+
+        params: resend.Broadcasts.ListClickedLinksParams = {
+            "limit": 1,
+            "before": "cursor-value",
+        }
+        clicked_links: resend.Broadcasts.ListClickedLinksResponse = (
+            resend.Broadcasts.clicked_links(
+                "559ac32e-9ef5-46fb-82a1-b76b840c0f7b", params=params
+            )
+        )
+        assert clicked_links["object"] == "list"
+        assert clicked_links["has_more"] is False
+        assert len(clicked_links["data"]) == 0


### PR DESCRIPTION
Adds `GET /broadcasts/{id}/clicked-links` — paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`).

Spec: resend/resend-openapi#95
Reference implementation: resend/resend-node#1077

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.Broadcasts.clicked_links()` and `clicked_links_async()` to list a broadcast’s clicked links from `GET /broadcasts/{id}/clicked-links`, enabling retrieval of URL, total clicks, and unique clicks with cursor pagination.

- Defines `ClickedLink` and `Broadcasts.ListClickedLinksResponse` (object, data, has_more) with optional `limit`, `after`, and `before`; exports `ClickedLink` from `resend.__init__`.
- Uses `PaginationHelper` for cursorized paths; adds sync/async tests and `NoContentError` coverage.
- Updates `examples/broadcasts.py` to demonstrate `clicked_links` usage.

<sup>Written for commit 79f56c45c22f576767462afa8b09e42110fcb40e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

