### PR TITLE
fix: take the broadcast id as a positional argument in recipients

### DIFF
--- a/examples/async/broadcasts_async.py
+++ b/examples/async/broadcasts_async.py
@@ -58,11 +58,10 @@ async def main() -> None:
     print(retrieved)
 
     recipients_params: resend.Broadcasts.RecipientsParams = {
-        "broadcast_id": broadcast["id"],
         "type": "delivered",
     }
     recipients: resend.Broadcasts.RecipientsResponse = (
-        await resend.Broadcasts.recipients_async(recipients_params)
+        await resend.Broadcasts.recipients_async(broadcast["id"], recipients_params)
     )
     print("Broadcast recipients !\n")
     print(f"Found {len(recipients['data'])} recipients")

--- a/examples/broadcasts.py
+++ b/examples/broadcasts.py
@@ -47,11 +47,10 @@ print("retrieved broadcast !\n")
 print(retrieved)
 
 recipients_params: resend.Broadcasts.RecipientsParams = {
-    "broadcast_id": broadcast["id"],
     "type": "delivered",
 }
 recipients: resend.Broadcasts.RecipientsResponse = resend.Broadcasts.recipients(
-    recipients_params
+    broadcast["id"], recipients_params
 )
 print("Broadcast recipients !\n")
 print(f"Found {len(recipients['data'])} recipients")

--- a/resend/broadcasts/_broadcasts.py
+++ b/resend/broadcasts/_broadcasts.py
@@ -246,7 +246,6 @@ class Broadcasts:
         """RecipientsParams is the class that wraps the parameters for the recipients method.
 
         Attributes:
-            broadcast_id (str): The ID of the broadcast.
             type (BroadcastRecipientEventType): The recipient event type to filter by.
             email (NotRequired[str]): Filter recipients by email address (substring match).
             bounce_type (NotRequired[BroadcastRecipientBounceType]): Filter bounced recipients
@@ -256,10 +255,6 @@ class Broadcasts:
             before (NotRequired[str]): The ID before which we'll retrieve more recipients (for pagination).
         """
 
-        broadcast_id: str
-        """
-        The ID of the broadcast.
-        """
         type: BroadcastRecipientEventType
         """
         The recipient event type to filter by.
@@ -495,20 +490,22 @@ class Broadcasts:
         return resp
 
     @classmethod
-    def recipients(cls, params: RecipientsParams) -> RecipientsResponse:
+    def recipients(cls, id: str, params: RecipientsParams) -> RecipientsResponse:
         """
         Retrieve a broadcast's recipients for a given event type.
         see more: https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients
 
         Args:
+            id (str): The broadcast ID
             params (RecipientsParams): The recipients filter and pagination parameters
 
         Returns:
             RecipientsResponse: A list of broadcast recipient objects
         """
-        base_path = f"/broadcasts/{params['broadcast_id']}/recipients"
-        query_params = {k: v for k, v in params.items() if k != "broadcast_id"}
-        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        base_path = f"/broadcasts/{id}/recipients"
+        path = PaginationHelper.build_paginated_path(
+            base_path, cast(Dict[Any, Any], params)
+        )
         resp = request.Request[Broadcasts.RecipientsResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()
@@ -670,20 +667,24 @@ class Broadcasts:
         return resp
 
     @classmethod
-    async def recipients_async(cls, params: RecipientsParams) -> RecipientsResponse:
+    async def recipients_async(
+        cls, id: str, params: RecipientsParams
+    ) -> RecipientsResponse:
         """
         Retrieve a broadcast's recipients for a given event type (async).
         see more: https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients
 
         Args:
+            id (str): The broadcast ID
             params (RecipientsParams): The recipients filter and pagination parameters
 
         Returns:
             RecipientsResponse: A list of broadcast recipient objects
         """
-        base_path = f"/broadcasts/{params['broadcast_id']}/recipients"
-        query_params = {k: v for k, v in params.items() if k != "broadcast_id"}
-        path = PaginationHelper.build_paginated_path(base_path, query_params)
+        base_path = f"/broadcasts/{id}/recipients"
+        path = PaginationHelper.build_paginated_path(
+            base_path, cast(Dict[Any, Any], params)
+        )
         resp = await AsyncRequest[Broadcasts.RecipientsResponse](
             path=path, params={}, verb="get"
         ).perform_with_content()

--- a/tests/broadcasts_async_test.py
+++ b/tests/broadcasts_async_test.py
@@ -242,11 +242,12 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "delivered",
         }
         recipients: resend.Broadcasts.RecipientsResponse = (
-            await resend.Broadcasts.recipients_async(params)
+            await resend.Broadcasts.recipients_async(
+                "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+            )
         )
         assert recipients["object"] == "list"
         assert recipients["has_more"] is False
@@ -274,10 +275,11 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "opened",
         }
-        recipients = await resend.Broadcasts.recipients_async(params)
+        recipients = await resend.Broadcasts.recipients_async(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+        )
         recipient = recipients["data"][0]
         assert recipient["contact_id"] is None
         assert recipient["count"] == 3
@@ -304,12 +306,13 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "clicked",
             "email": "carter",
             "limit": 10,
         }
-        recipients = await resend.Broadcasts.recipients_async(params)
+        recipients = await resend.Broadcasts.recipients_async(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+        )
         recipient = recipients["data"][0]
         assert recipient["count"] == 2
         assert recipient["clicked_links"] == [
@@ -335,11 +338,12 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "bounced",
             "bounce_type": "permanent",
         }
-        recipients = await resend.Broadcasts.recipients_async(params)
+        recipients = await resend.Broadcasts.recipients_async(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+        )
         recipient = recipients["data"][0]
         assert recipient["bounce_type"] == "permanent"
 
@@ -355,22 +359,22 @@ class TestResendBroadcastsAsync(AsyncResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "does-not-exist",
             "type": "sent",
         }
         with pytest.raises(ResendError):
-            _ = await resend.Broadcasts.recipients_async(params)
+            _ = await resend.Broadcasts.recipients_async("does-not-exist", params)
 
     async def test_should_recipients_broadcasts_async_raise_exception_when_no_content(
         self,
     ) -> None:
         self.set_mock_json(None)
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "sent",
         }
         with pytest.raises(NoContentError):
-            _ = await resend.Broadcasts.recipients_async(params)
+            _ = await resend.Broadcasts.recipients_async(
+                "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+            )
 
     async def test_broadcasts_clicked_links_async(self) -> None:
         self.set_mock_json(

--- a/tests/broadcasts_test.py
+++ b/tests/broadcasts_test.py
@@ -258,11 +258,10 @@ class TestResendBroadcasts(ResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "delivered",
         }
         recipients: resend.Broadcasts.RecipientsResponse = resend.Broadcasts.recipients(
-            params
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
         )
         assert recipients["object"] == "list"
         assert recipients["has_more"] is False
@@ -290,10 +289,11 @@ class TestResendBroadcasts(ResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "opened",
         }
-        recipients = resend.Broadcasts.recipients(params)
+        recipients = resend.Broadcasts.recipients(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+        )
         recipient = recipients["data"][0]
         assert recipient["contact_id"] is None
         assert recipient["count"] == 3
@@ -318,12 +318,13 @@ class TestResendBroadcasts(ResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "clicked",
             "email": "carter",
             "limit": 10,
         }
-        recipients = resend.Broadcasts.recipients(params)
+        recipients = resend.Broadcasts.recipients(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+        )
         recipient = recipients["data"][0]
         assert recipient["count"] == 2
         assert recipient["clicked_links"] == [
@@ -347,11 +348,12 @@ class TestResendBroadcasts(ResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "type": "bounced",
             "bounce_type": "permanent",
         }
-        recipients = resend.Broadcasts.recipients(params)
+        recipients = resend.Broadcasts.recipients(
+            "78261eea-8f8b-4381-83c6-79fa7120f1cf", params
+        )
         recipient = recipients["data"][0]
         assert recipient["bounce_type"] == "permanent"
 
@@ -365,11 +367,10 @@ class TestResendBroadcasts(ResendBaseTest):
         )
 
         params: resend.Broadcasts.RecipientsParams = {
-            "broadcast_id": "does-not-exist",
             "type": "sent",
         }
         with self.assertRaises(ResendError):
-            _ = resend.Broadcasts.recipients(params)
+            _ = resend.Broadcasts.recipients("does-not-exist", params)
 
     def test_broadcasts_clicked_links(self) -> None:
         self.set_mock_json(


### PR DESCRIPTION
## What

Change `Broadcasts.recipients(params)` to `Broadcasts.recipients(id, params)`, and the same for `recipients_async`. Remove `broadcast_id` from `RecipientsParams`. Update the tests and both examples.

## Why

#261 put the broadcast id inside the params dict. Every sibling GET with a path id takes a positional id: `clicked_links` in the same class, `Attachments.list`, `Emails.share`, `Receiving.get`. The old shape also forced the impl to filter the id back out of the query dict.

The method is merged but not released (no tag contains it), so the signature change is not breaking.

## Verification

- `pytest --doctest-modules tests`: 614 passed.
- `flake8` and `mypy` (CI flags): clean.
- Live call against the real API with the new signature: `type=sent` returns the recipient list, the `email` substring filter works, and a bad id raises `ResendError` (404).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Broadcasts.recipients and recipients_async take the broadcast id as a positional argument and remove broadcast_id from RecipientsParams. This aligns recipients with other path-id GETs and simplifies query construction.

- Bold text intended -
- But not more than two sections possible...

<sup>Written for commit 5c2718c8c726396fd91a7f7a0ee4cd2f95bf79e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

