### PR TITLE
chore: bump version to 2.40.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.39.0"
+__version__ = "2.40.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bumps the version for the release that ships:
- Emails.metrics() (#262)
- broadcasts.recipients() (#261)
- broadcasts.clicked_links() (#263)
- fix: take the broadcast id as a positional argument in recipients (#264)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the library version to 2.40.0 to publish new Email and Broadcast APIs and a recipients signature fix. Old: `broadcasts.recipients` required a keyword `broadcast_id`. New: it takes the broadcast id as the first positional argument.

- Adds `Emails.metrics()`, `broadcasts.recipients()`, and `broadcasts.clicked_links()`.
- Migration: update calls to `broadcasts.recipients(broadcast_id=...)` to `broadcasts.recipients(broadcast_id, ...)`.

<sup>Written for commit 797abf7dfb317a60299d89eba5d87ad55f5b2595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

