### PR TITLE
chore: bump version to 2.41.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.40.2"
+__version__ = "2.41.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump `__version__` to 2.41.0. Minor release covering #270 (`Segments.update`/`update_async`).