### PR TITLE
chore: bump version to 2.40.1

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.40.0"
+__version__ = "2.40.1"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Releases two unreleased type corrections:

- [#254](https://github.com/resend/resend-python/pull/254) — `Contact.properties` is `Dict[str, ContactPropertyValue]`, the `{value, type}` shape the API actually returns ([DEV-1624](https://linear.app/resend/issue/DEV-1624/get-contact-properties-response-is-inconsistent-with-docs))
- [#255](https://github.com/resend/resend-python/pull/255) — contact `first_name` / `last_name` are `Optional[str]` on responses and `NotRequired[Optional[str]]` on webhook events ([DEV-1625](https://linear.app/resend/issue/DEV-1625/allow-nullable-contact-first-and-last-names-in-openapi))

Patch: type-only corrections, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `resend` 2.40.1 to release two type-only contact model corrections. Aligns published typings with the API; no runtime or API surface changes.

- `Contact.properties` is `Dict[str, ContactPropertyValue]` representing the `{ value, type }` shape (DEV-1624).
- `first_name` and `last_name` are `Optional[str]` in responses and `NotRequired[Optional[str]]` in webhook events (DEV-1625).

<sup>Written for commit 576a0206d2b717ea9a56f7724d7a3502466bee46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

