### PR TITLE
fix(api-keys): rename the update params key to id

### DIFF
--- a/examples/api_keys.py
+++ b/examples/api_keys.py
@@ -17,7 +17,7 @@ print("Created new api key")
 print(f"Key id: {created_key['id']} and token: {created_key['token']}")
 
 update_params: resend.ApiKeys.UpdateParams = {
-    "api_key_id": created_key["id"],
+    "id": created_key["id"],
     "name": "renamed-example",
 }
 updated_key: resend.ApiKeys.UpdateApiKeyResponse = resend.ApiKeys.update(update_params)

--- a/examples/async/api_keys_async.py
+++ b/examples/async/api_keys_async.py
@@ -20,7 +20,7 @@ async def main() -> None:
     print(f"Key id: {key['id']} and token: {key['token']}")
 
     update_params: resend.ApiKeys.UpdateParams = {
-        "api_key_id": key["id"],
+        "id": key["id"],
         "name": "renamed-example",
     }
     updated_key = await resend.ApiKeys.update_async(update_params)

--- a/resend/api_keys/_api_keys.py
+++ b/resend/api_keys/_api_keys.py
@@ -134,7 +134,7 @@ class ApiKeys:
         """
 
     class UpdateParams(TypedDict):
-        api_key_id: str
+        id: str
         """
         The API key ID.
         """
@@ -169,13 +169,13 @@ class ApiKeys:
 
         Args:
             params (UpdateParams): The API key update parameters
-                - api_key_id: The API key ID
+                - id: The API key ID
                 - name: The new API key name
 
         Returns:
             UpdateApiKeyResponse: The updated API key response with id
         """
-        api_key_id = params["api_key_id"]
+        api_key_id = params["id"]
         path = f"/api-keys/{api_key_id}"
         resp = request.Request[ApiKeys.UpdateApiKeyResponse](
             path=path, params={"name": params["name"]}, verb="patch"
@@ -249,13 +249,13 @@ class ApiKeys:
 
         Args:
             params (UpdateParams): The API key update parameters
-                - api_key_id: The API key ID
+                - id: The API key ID
                 - name: The new API key name
 
         Returns:
             UpdateApiKeyResponse: The updated API key response with id
         """
-        api_key_id = params["api_key_id"]
+        api_key_id = params["id"]
         path = f"/api-keys/{api_key_id}"
         resp = await AsyncRequest[ApiKeys.UpdateApiKeyResponse](
             path=path, params={"name": params["name"]}, verb="patch"

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.40.1"
+__version__ = "2.40.2"
 
 
 def get_version() -> str:

--- a/tests/api_keys_async_test.py
+++ b/tests/api_keys_async_test.py
@@ -69,7 +69,7 @@ class TestResendApiKeysAsync(AsyncResendBaseTest):
         )
 
         params: resend.ApiKeys.UpdateParams = {
-            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
             "name": "updated-name",
         }
         updated_key: resend.ApiKeys.UpdateApiKeyResponse = (
@@ -83,7 +83,7 @@ class TestResendApiKeysAsync(AsyncResendBaseTest):
     ) -> None:
         self.set_mock_json(None)
         params: resend.ApiKeys.UpdateParams = {
-            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
             "name": "updated-name",
         }
         with pytest.raises(NoContentError):

--- a/tests/api_keys_test.py
+++ b/tests/api_keys_test.py
@@ -136,7 +136,7 @@ class TestResendApiKeys(ResendBaseTest):
         )
 
         params: resend.ApiKeys.UpdateParams = {
-            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
             "name": "updated-name",
         }
         updated_key: resend.ApiKeys.UpdateApiKeyResponse = resend.ApiKeys.update(params)
@@ -146,7 +146,7 @@ class TestResendApiKeys(ResendBaseTest):
     def test_should_update_api_key_raise_exception_when_no_content(self) -> None:
         self.set_mock_json(None)
         params: resend.ApiKeys.UpdateParams = {
-            "api_key_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+            "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
             "name": "updated-name",
         }
         with self.assertRaises(NoContentError):


### PR DESCRIPTION
## What

`ApiKeys.update` takes `params["api_key_id"]`; every other update params dict in the SDK uses `id`:

```python
Domains.update({"id": ...})
Emails.update({"id": ...})
Templates.update({"id": ...})
ContactProperties.update({"id": ...})
ApiKeys.update({"api_key_id": ...})   # the exception
```

This renames the key to `id` in the TypedDict, both method bodies, the tests, and both examples, and bumps the version to 2.40.2.

## Why a clean rename is safe

The method shipped yesterday (v2.40.0, 2026-08-24). Datadog traces for `PATCH /api-keys/:apiKeyId` since then show 33 requests; the indexed spans group into two user agents, `node` and `resend-remote-mcp:1.0.0`. Zero calls from resend-python. There is nobody to break, so no deprecation alias.

## Scope

`remove(api_key_id=...)` keeps its name: positional id parameters ship in both forms across the SDK (`id` in audiences/broadcasts/contact_properties, `<resource>_id` in domains/emails/automations), and its kwarg form is long documented.

## Checks

pytest 614 passed; mypy clean; flake8 clean (flake8 7.x locally, CI pins <5).

Follow-up: the Python tab on docs update-api-key.mdx teaches `"api_key_id"` and needs the same rename when this releases.