### PR TITLE
feat: add update/update_async for renaming a segment

### DIFF
--- a/examples/segments.py
+++ b/examples/segments.py
@@ -19,6 +19,15 @@ seg: resend.Segment = resend.Segments.get(segment["id"])
 print(f"\n✓ Retrieved segment: {seg['name']}")
 print(f"  Created at: {seg['created_at']}")
 
+# Update the segment's name
+update_params: resend.Segments.UpdateParams = {
+    "name": "VIP Newsletter Subscribers (renamed)",
+}
+updated_segment: resend.Segments.UpdateSegmentResponse = resend.Segments.update(
+    id=segment["id"], params=update_params
+)
+print(f"\n✓ Updated segment: {updated_segment['name']}")
+
 # List all segments
 segments: resend.Segments.ListResponse = resend.Segments.list()
 print(f"\n✓ List of segments: {[s['name'] for s in segments['data']]}")

--- a/examples/segments.py
+++ b/examples/segments.py
@@ -26,7 +26,7 @@ update_params: resend.Segments.UpdateParams = {
 updated_segment: resend.Segments.UpdateSegmentResponse = resend.Segments.update(
     id=segment["id"], params=update_params
 )
-print(f"\n✓ Updated segment: {updated_segment['name']}")
+print(f"\n✓ Updated segment: {updated_segment['id']}")
 
 # List all segments
 segments: resend.Segments.ListResponse = resend.Segments.list()

--- a/resend/segments/_segments.py
+++ b/resend/segments/_segments.py
@@ -110,6 +110,35 @@ class Segments:
         The name of the segment.
         """
 
+    class UpdateSegmentResponse(BaseResponse):
+        """
+        UpdateSegmentResponse is the type that wraps the response of the segment that was updated
+
+        Attributes:
+            object (str): The object type, "segment"
+            id (str): The ID of the updated segment
+            name (str): The name of the updated segment
+        """
+
+        object: str
+        """
+        The object type, "segment"
+        """
+        id: str
+        """
+        The ID of the updated segment
+        """
+        name: str
+        """
+        The name of the updated segment
+        """
+
+    class UpdateParams(TypedDict):
+        name: str
+        """
+        The new name of the segment.
+        """
+
     @classmethod
     def create(cls, params: CreateParams) -> CreateSegmentResponse:
         """
@@ -168,6 +197,26 @@ class Segments:
         path = f"/segments/{id}"
         resp = request.Request[Segment](
             path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    def update(cls, id: str, params: UpdateParams) -> UpdateSegmentResponse:
+        """
+        Update an existing segment's name.
+        see more: https://resend.com/docs/api-reference/segments/update-segment
+
+        Args:
+            id (str): The segment ID
+            params (UpdateParams): The segment update parameters
+                - name: The new name of the segment
+
+        Returns:
+            UpdateSegmentResponse: The updated segment response
+        """
+        path = f"/segments/{id}"
+        resp = request.Request[Segments.UpdateSegmentResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
 
@@ -242,6 +291,26 @@ class Segments:
         path = f"/segments/{id}"
         resp = await AsyncRequest[Segment](
             path=path, params={}, verb="get"
+        ).perform_with_content()
+        return resp
+
+    @classmethod
+    async def update_async(cls, id: str, params: UpdateParams) -> UpdateSegmentResponse:
+        """
+        Update an existing segment's name (async).
+        see more: https://resend.com/docs/api-reference/segments/update-segment
+
+        Args:
+            id (str): The segment ID
+            params (UpdateParams): The segment update parameters
+                - name: The new name of the segment
+
+        Returns:
+            UpdateSegmentResponse: The updated segment response
+        """
+        path = f"/segments/{id}"
+        resp = await AsyncRequest[Segments.UpdateSegmentResponse](
+            path=path, params=cast(Dict[Any, Any], params), verb="patch"
         ).perform_with_content()
         return resp
 

--- a/resend/segments/_segments.py
+++ b/resend/segments/_segments.py
@@ -117,7 +117,6 @@ class Segments:
         Attributes:
             object (str): The object type, "segment"
             id (str): The ID of the updated segment
-            name (str): The name of the updated segment
         """
 
         object: str
@@ -127,10 +126,6 @@ class Segments:
         id: str
         """
         The ID of the updated segment
-        """
-        name: str
-        """
-        The name of the updated segment
         """
 
     class UpdateParams(TypedDict):

--- a/tests/segments_async_test.py
+++ b/tests/segments_async_test.py
@@ -15,7 +15,6 @@ class TestResendSegmentsAsync(AsyncResendBaseTest):
             {
                 "object": "segment",
                 "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-                "name": "Renamed Segment",
             }
         )
 
@@ -27,7 +26,6 @@ class TestResendSegmentsAsync(AsyncResendBaseTest):
         )
         assert segment["object"] == "segment"
         assert segment["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
-        assert segment["name"] == "Renamed Segment"
 
     async def test_should_update_segments_async_raise_exception_when_no_content(
         self,

--- a/tests/segments_async_test.py
+++ b/tests/segments_async_test.py
@@ -1,0 +1,42 @@
+import pytest
+
+import resend
+from resend.exceptions import NoContentError
+from tests.conftest import AsyncResendBaseTest
+
+# flake8: noqa
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestResendSegmentsAsync(AsyncResendBaseTest):
+    async def test_segments_update_async(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "segment",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+                "name": "Renamed Segment",
+            }
+        )
+
+        params: resend.Segments.UpdateParams = {
+            "name": "Renamed Segment",
+        }
+        segment = await resend.Segments.update_async(
+            id="78261eea-8f8b-4381-83c6-79fa7120f1cf", params=params
+        )
+        assert segment["object"] == "segment"
+        assert segment["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert segment["name"] == "Renamed Segment"
+
+    async def test_should_update_segments_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        params: resend.Segments.UpdateParams = {
+            "name": "Renamed Segment",
+        }
+        with pytest.raises(NoContentError):
+            _ = await resend.Segments.update_async(
+                id="78261eea-8f8b-4381-83c6-79fa7120f1cf", params=params
+            )

--- a/tests/segments_async_test.py
+++ b/tests/segments_async_test.py
@@ -27,7 +27,7 @@ class TestResendSegmentsAsync(AsyncResendBaseTest):
         assert segment["object"] == "segment"
         assert segment["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
 
-    async def test_should_update_segments_async_raise_exception_when_no_content(
+    async def test_update_segments_async_raises_exception_when_no_content(
         self,
     ) -> None:
         self.set_mock_json(None)

--- a/tests/segments_test.py
+++ b/tests/segments_test.py
@@ -55,7 +55,6 @@ class TestResendSegments(ResendBaseTest):
             {
                 "object": "segment",
                 "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-                "name": "Renamed Segment",
             }
         )
 
@@ -67,7 +66,6 @@ class TestResendSegments(ResendBaseTest):
         )
         assert segment["object"] == "segment"
         assert segment["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
-        assert segment["name"] == "Renamed Segment"
 
     def test_should_update_segments_raise_exception_when_no_content(self) -> None:
         self.set_mock_json(None)

--- a/tests/segments_test.py
+++ b/tests/segments_test.py
@@ -50,6 +50,35 @@ class TestResendSegments(ResendBaseTest):
         with self.assertRaises(NoContentError):
             _ = resend.Segments.get(id="78261eea-8f8b-4381-83c6-79fa7120f1cf")
 
+    def test_segments_update(self) -> None:
+        self.set_mock_json(
+            {
+                "object": "segment",
+                "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+                "name": "Renamed Segment",
+            }
+        )
+
+        params: resend.Segments.UpdateParams = {
+            "name": "Renamed Segment",
+        }
+        segment = resend.Segments.update(
+            id="78261eea-8f8b-4381-83c6-79fa7120f1cf", params=params
+        )
+        assert segment["object"] == "segment"
+        assert segment["id"] == "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+        assert segment["name"] == "Renamed Segment"
+
+    def test_should_update_segments_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        params: resend.Segments.UpdateParams = {
+            "name": "Renamed Segment",
+        }
+        with self.assertRaises(NoContentError):
+            _ = resend.Segments.update(
+                id="78261eea-8f8b-4381-83c6-79fa7120f1cf", params=params
+            )
+
     def test_segments_remove(self) -> None:
         self.set_mock_json(
             {


### PR DESCRIPTION
Adds `Segments.update()` / `Segments.update_async()` for `PATCH /segments/:id`, which renames a segment. Mirrors the existing `Topics.update()` implementation.

```python
import resend

resend.api_key = "re_xxxxxxxxx"

params: resend.Segments.UpdateParams = {
    "name": "New segment name",
}

segment = resend.Segments.update(id="78261eea-8f8b-4381-83c6-79fa7120f1cf", params=params)
```

**Params**

| Name | Type   | Required |
| ---- | ------ | -------- |
| name | string | Yes      |

**Response**

```json
{
  "object": "segment",
  "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf"
}
```