### PR TITLE
chore: bump version to 2.42.0

### DIFF
--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.41.0"
+__version__ = "2.42.0"
 
 
 def get_version() -> str:


### PR DESCRIPTION
Bump the client version to 2.42.0. Minor release covering #268 (webhook event listing endpoints).

Linear: https://linear.app/resend/issue/DEV-1926

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the client version to `2.42.0` to include the webhook event listing endpoints from #268. No API behavior changes; this release only exposes the new endpoints.

<sup>Written for commit dd45d2fdaa9357229169c7c18b0a23f44a2ae22f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

