### PR TITLE
docs(webhooks): document event listing methods

### DIFF
--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -363,6 +363,17 @@ class Webhooks:
     def list_events(
         cls, webhook_id: str, params: Optional[ListEventsParams] = None
     ) -> ListEventsResponse:
+        """
+        Retrieve a list of events delivered to a webhook.
+        see more: https://resend.com/docs/api-reference/webhooks/list-events
+
+        Args:
+            webhook_id (str): The webhook ID
+            params (Optional[ListEventsParams]): Optional pagination parameters
+
+        Returns:
+            ListEventsResponse: A list of webhook events
+        """
         base_path = f"/webhooks/{webhook_id}/events"
         query_params = cast(Dict[Any, Any], params) if params else None
         path = PaginationHelper.build_paginated_path(base_path, query_params)
@@ -372,6 +383,17 @@ class Webhooks:
 
     @classmethod
     def get_event(cls, webhook_id: str, event_id: str) -> GetEventResponse:
+        """
+        Retrieve a single event delivered to a webhook.
+        see more: https://resend.com/docs/api-reference/webhooks/get-event
+
+        Args:
+            webhook_id (str): The webhook ID
+            event_id (str): The webhook event ID
+
+        Returns:
+            GetEventResponse: The webhook event
+        """
         path = f"/webhooks/{webhook_id}/events/{event_id}"
         return request.Request[Webhooks.GetEventResponse](
             path=path, params={}, verb="get"
@@ -384,6 +406,18 @@ class Webhooks:
         event_id: str,
         params: Optional[ListEventAttemptsParams] = None,
     ) -> ListEventAttemptsResponse:
+        """
+        Retrieve the delivery attempts for a webhook event.
+        see more: https://resend.com/docs/api-reference/webhooks/list-event-attempts
+
+        Args:
+            webhook_id (str): The webhook ID
+            event_id (str): The webhook event ID
+            params (Optional[ListEventAttemptsParams]): Optional pagination parameters
+
+        Returns:
+            ListEventAttemptsResponse: A list of delivery attempts
+        """
         base_path = f"/webhooks/{webhook_id}/events/{event_id}/attempts"
         query_params = cast(Dict[Any, Any], params) if params else None
         path = PaginationHelper.build_paginated_path(base_path, query_params)
@@ -588,6 +622,17 @@ class Webhooks:
     async def list_events_async(
         cls, webhook_id: str, params: Optional[ListEventsParams] = None
     ) -> ListEventsResponse:
+        """
+        Retrieve a list of events delivered to a webhook (async).
+        see more: https://resend.com/docs/api-reference/webhooks/list-events
+
+        Args:
+            webhook_id (str): The webhook ID
+            params (Optional[ListEventsParams]): Optional pagination parameters
+
+        Returns:
+            ListEventsResponse: A list of webhook events
+        """
         base_path = f"/webhooks/{webhook_id}/events"
         query_params = cast(Dict[Any, Any], params) if params else None
         path = PaginationHelper.build_paginated_path(base_path, query_params)
@@ -597,6 +642,17 @@ class Webhooks:
 
     @classmethod
     async def get_event_async(cls, webhook_id: str, event_id: str) -> GetEventResponse:
+        """
+        Retrieve a single event delivered to a webhook (async).
+        see more: https://resend.com/docs/api-reference/webhooks/get-event
+
+        Args:
+            webhook_id (str): The webhook ID
+            event_id (str): The webhook event ID
+
+        Returns:
+            GetEventResponse: The webhook event
+        """
         path = f"/webhooks/{webhook_id}/events/{event_id}"
         return await AsyncRequest[Webhooks.GetEventResponse](
             path=path, params={}, verb="get"
@@ -609,6 +665,18 @@ class Webhooks:
         event_id: str,
         params: Optional[ListEventAttemptsParams] = None,
     ) -> ListEventAttemptsResponse:
+        """
+        Retrieve the delivery attempts for a webhook event (async).
+        see more: https://resend.com/docs/api-reference/webhooks/list-event-attempts
+
+        Args:
+            webhook_id (str): The webhook ID
+            event_id (str): The webhook event ID
+            params (Optional[ListEventAttemptsParams]): Optional pagination parameters
+
+        Returns:
+            ListEventAttemptsResponse: A list of delivery attempts
+        """
         base_path = f"/webhooks/{webhook_id}/events/{event_id}/attempts"
         query_params = cast(Dict[Any, Any], params) if params else None
         path = PaginationHelper.build_paginated_path(base_path, query_params)


### PR DESCRIPTION
## Summary

- document the synchronous webhook event APIs
- document the asynchronous webhook event APIs

## Testing

- `uvx --from tox tox -e lint,mypy,py`

Linear: https://linear.app/resend/issue/DEV-1926

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docstrings to the sync and async webhook event methods (`list_events`, `get_event`, `list_event_attempts`) so the API reference is complete. This is a docs-only change; no behavior changes or migrations required. Addresses DEV-1926.

<sup>Written for commit 3ee1a24b233917475867be9de7028b11328cc003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

