### PR TITLE
feat(contacts): add type for segments in contact creation

### DIFF
--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -132,6 +132,12 @@ class Contacts:
         The ID of the updated contact.
         """
 
+    class CreateParamsSegment(TypedDict):
+        id: str
+        """
+        The segment id.
+        """
+
     class CreateParams(TypedDict):
         email: str
         """
@@ -152,6 +158,10 @@ class Contacts:
         unsubscribed: NotRequired[bool]
         """
         The unsubscribed status of the contact.
+        """
+        segments: NotRequired[List[CreateParamsSegment]]
+        """
+        Segments to add the contact to. Each entry must have an id.
         """
         properties: NotRequired[Dict[str, Any]]
         """

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Literal, Optional, cast
 from urllib.parse import quote
 
 from typing_extensions import NotRequired, TypedDict
@@ -138,6 +138,19 @@ class Contacts:
         The segment id.
         """
 
+    class CreateParamsTopic(TypedDict):
+        id: str
+        """
+        The topic id.
+        """
+        subscription: Literal[
+            "opt_in",
+            "opt_out",
+        ]
+        """
+        The subscription status of the topic.
+        """
+
     class CreateParams(TypedDict):
         email: str
         """
@@ -162,6 +175,10 @@ class Contacts:
         segments: NotRequired[List[CreateParamsSegment]]
         """
         Segments to add the contact to. Each entry must have an id.
+        """
+        topics: NotRequired[List[CreateParamsTopic]]
+        """
+        Topics to add the contact to. Each entry must have an id and subscription status.
         """
         properties: NotRequired[Dict[str, Any]]
         """

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -19,6 +19,27 @@ except ImportError:
     pass
 
 
+class CreateParamsSegment(TypedDict):
+    id: str
+    """
+    The segment id.
+    """
+
+
+class CreateParamsTopic(TypedDict):
+    id: str
+    """
+    The topic id.
+    """
+    subscription: Literal[
+        "opt_in",
+        "opt_out",
+    ]
+    """
+    The subscription status of the topic.
+    """
+
+
 class Contacts:
     # Sub-API for managing contact-segment associations
     Segments = ContactSegments
@@ -132,25 +153,6 @@ class Contacts:
         The ID of the updated contact.
         """
 
-    class CreateParamsSegment(TypedDict):
-        id: str
-        """
-        The segment id.
-        """
-
-    class CreateParamsTopic(TypedDict):
-        id: str
-        """
-        The topic id.
-        """
-        subscription: Literal[
-            "opt_in",
-            "opt_out",
-        ]
-        """
-        The subscription status of the topic.
-        """
-
     class CreateParams(TypedDict):
         email: str
         """
@@ -172,11 +174,11 @@ class Contacts:
         """
         The unsubscribed status of the contact.
         """
-        segments: NotRequired[List[Contacts.CreateParamsSegment]]
+        segments: NotRequired[List[CreateParamsSegment]]
         """
         Segments to add the contact to. Each entry must have an id.
         """
-        topics: NotRequired[List[Contacts.CreateParamsTopic]]
+        topics: NotRequired[List[CreateParamsTopic]]
         """
         Topics to add the contact to. Each entry must have an id and subscription status.
         """

--- a/resend/contacts/_contacts.py
+++ b/resend/contacts/_contacts.py
@@ -172,11 +172,11 @@ class Contacts:
         """
         The unsubscribed status of the contact.
         """
-        segments: NotRequired[List[CreateParamsSegment]]
+        segments: NotRequired[List[Contacts.CreateParamsSegment]]
         """
         Segments to add the contact to. Each entry must have an id.
         """
-        topics: NotRequired[List[CreateParamsTopic]]
+        topics: NotRequired[List[Contacts.CreateParamsTopic]]
         """
         Topics to add the contact to. Each entry must have an id and subscription status.
         """


### PR DESCRIPTION
Not having the `segments` or `topics` property types wouldn't cause runtime failures, but could cause a type checker to have a bad time.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing `segments` and `topics` type definitions for contact creation so type checkers validate them correctly, and points `ListParams` at the new types by their full path.

<sup>Written for commit 36f7805bfc950099f6ba286f3055a7b140a2db0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



