### PR TITLE
feat(webhooks): add event replay endpoint

### DIFF
--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -71,6 +71,11 @@ if webhook_events["data"]:
     )
     print(f"Retrieved webhook event: {webhook_event['id']}")
 
+    replayed: resend.Webhooks.ReplayEventResponse = resend.Webhooks.replay_event(
+        webhook["id"], event_id
+    )
+    print(f"Replayed webhook event: {replayed['id']}")
+
     attempts: resend.Webhooks.ListEventAttemptsResponse = (
         resend.Webhooks.list_event_attempts(webhook["id"], event_id, {"limit": 10})
     )

--- a/resend/webhooks/_webhooks.py
+++ b/resend/webhooks/_webhooks.py
@@ -107,6 +107,16 @@ class Webhooks:
         The webhook event payload.
         """
 
+    class ReplayEventResponse(BaseResponse):
+        object: str
+        """
+        The object type, always "webhook_event".
+        """
+        id: str
+        """
+        The webhook event ID.
+        """
+
     class WebhookEventAttempt(TypedDict):
         id: str
         """
@@ -400,6 +410,24 @@ class Webhooks:
         ).perform_with_content()
 
     @classmethod
+    def replay_event(cls, webhook_id: str, event_id: str) -> ReplayEventResponse:
+        """
+        Queue one more delivery of a webhook event to its webhook.
+        see more: https://resend.com/docs/api-reference/webhooks/replay-event
+
+        Args:
+            webhook_id (str): The webhook ID
+            event_id (str): The webhook event ID
+
+        Returns:
+            ReplayEventResponse: The replayed webhook event
+        """
+        path = f"/webhooks/{webhook_id}/events/{event_id}/replay"
+        return request.Request[Webhooks.ReplayEventResponse](
+            path=path, params={}, verb="post"
+        ).perform_with_content()
+
+    @classmethod
     def list_event_attempts(
         cls,
         webhook_id: str,
@@ -656,6 +684,26 @@ class Webhooks:
         path = f"/webhooks/{webhook_id}/events/{event_id}"
         return await AsyncRequest[Webhooks.GetEventResponse](
             path=path, params={}, verb="get"
+        ).perform_with_content()
+
+    @classmethod
+    async def replay_event_async(
+        cls, webhook_id: str, event_id: str
+    ) -> ReplayEventResponse:
+        """
+        Queue one more delivery of a webhook event to its webhook (async).
+        see more: https://resend.com/docs/api-reference/webhooks/replay-event
+
+        Args:
+            webhook_id (str): The webhook ID
+            event_id (str): The webhook event ID
+
+        Returns:
+            ReplayEventResponse: The replayed webhook event
+        """
+        path = f"/webhooks/{webhook_id}/events/{event_id}/replay"
+        return await AsyncRequest[Webhooks.ReplayEventResponse](
+            path=path, params={}, verb="post"
         ).perform_with_content()
 
     @classmethod

--- a/tests/webhooks_async_test.py
+++ b/tests/webhooks_async_test.py
@@ -160,6 +160,22 @@ class TestResendWebhooksAsync(AsyncResendBaseTest):
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
+    async def test_webhooks_replay_event_async(self) -> None:
+        response = {
+            "object": "webhook_event",
+            "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+        }
+        self.set_mock_json(response)
+
+        event = await resend.Webhooks.replay_event_async(
+            "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        )
+
+        assert event == response
+        self.mock.assert_awaited_once_with(
+            url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
+        )
+
     async def test_webhooks_list_event_attempts_async(self) -> None:
         response = {
             "object": "list",

--- a/tests/webhooks_async_test.py
+++ b/tests/webhooks_async_test.py
@@ -162,33 +162,6 @@ class TestResendWebhooksAsync(AsyncResendBaseTest):
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
-    async def test_webhooks_replay_event_async(self) -> None:
-        self.patcher.stop()
-        client = AsyncMock()
-        client.request.return_value = (
-            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
-            200,
-            {"Content-Type": "application/json"},
-        )
-        original_client = resend.default_async_http_client
-        resend.default_async_http_client = client
-
-        try:
-            event = await resend.Webhooks.replay_event_async(
-                "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
-            )
-        finally:
-            resend.default_async_http_client = original_client
-
-        assert event["object"] == "webhook_event"
-        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
-        _, kwargs = client.request.call_args
-        assert kwargs["method"] == "post"
-        assert (
-            kwargs["url"]
-            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
-        )
-
     async def test_webhooks_list_event_attempts_async(self) -> None:
         response = {
             "object": "list",
@@ -237,3 +210,33 @@ class TestResendWebhooksAsync(AsyncResendBaseTest):
         self.set_mock_json(None)
         with pytest.raises(NoContentError):
             _ = await resend.Webhooks.remove_async("wh_123")
+
+
+class TestWebhooksRequestAsync:
+    def setup_method(self) -> None:
+        resend.api_key = "re_123"
+        self.mock_client = AsyncMock()
+        self.mock_client.request.return_value = (
+            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
+            200,
+            {"content-type": "application/json"},
+        )
+        self.previous_async_http_client = resend.default_async_http_client
+        resend.default_async_http_client = self.mock_client
+
+    def teardown_method(self) -> None:
+        resend.default_async_http_client = self.previous_async_http_client
+
+    async def test_replay_event_async_posts_to_the_replay_path(self) -> None:
+        event = await resend.Webhooks.replay_event_async(
+            "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        )
+
+        assert event["object"] == "webhook_event"
+        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        _, kwargs = self.mock_client.request.call_args
+        assert kwargs["method"] == "post"
+        assert (
+            kwargs["url"]
+            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
+        )

--- a/tests/webhooks_async_test.py
+++ b/tests/webhooks_async_test.py
@@ -162,6 +162,15 @@ class TestResendWebhooksAsync(AsyncResendBaseTest):
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
+    async def test_should_replay_event_async_raise_exception_when_no_content(
+        self,
+    ) -> None:
+        self.set_mock_json(None)
+        with pytest.raises(NoContentError):
+            _ = await resend.Webhooks.replay_event_async(
+                "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+            )
+
     async def test_webhooks_list_event_attempts_async(self) -> None:
         response = {
             "object": "list",

--- a/tests/webhooks_async_test.py
+++ b/tests/webhooks_async_test.py
@@ -162,7 +162,7 @@ class TestResendWebhooksAsync(AsyncResendBaseTest):
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
-    async def test_should_replay_event_async_raise_exception_when_no_content(
+    async def test_replay_event_async_raises_exception_when_no_content(
         self,
     ) -> None:
         self.set_mock_json(None)

--- a/tests/webhooks_async_test.py
+++ b/tests/webhooks_async_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 import resend
@@ -161,19 +163,30 @@ class TestResendWebhooksAsync(AsyncResendBaseTest):
         )
 
     async def test_webhooks_replay_event_async(self) -> None:
-        response = {
-            "object": "webhook_event",
-            "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
-        }
-        self.set_mock_json(response)
-
-        event = await resend.Webhooks.replay_event_async(
-            "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        self.patcher.stop()
+        client = AsyncMock()
+        client.request.return_value = (
+            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
+            200,
+            {"Content-Type": "application/json"},
         )
+        original_client = resend.default_async_http_client
+        resend.default_async_http_client = client
 
-        assert event == response
-        self.mock.assert_awaited_once_with(
-            url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
+        try:
+            event = await resend.Webhooks.replay_event_async(
+                "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+            )
+        finally:
+            resend.default_async_http_client = original_client
+
+        assert event["object"] == "webhook_event"
+        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        _, kwargs = client.request.call_args
+        assert kwargs["method"] == "post"
+        assert (
+            kwargs["url"]
+            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
         )
 
     async def test_webhooks_list_event_attempts_async(self) -> None:

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -9,6 +9,7 @@ from unittest.mock import create_autospec
 import pytest
 
 import resend
+from resend.exceptions import NoContentError
 from resend.http_client import HTTPClient
 from tests.conftest import ResendBaseTest
 
@@ -134,6 +135,13 @@ class TestWebhooks(ResendBaseTest):
         self.mock.assert_called_once_with(
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
+
+    def test_should_replay_event_raise_exception_when_no_content(self) -> None:
+        self.set_mock_json(None)
+        with pytest.raises(NoContentError):
+            _ = resend.Webhooks.replay_event(
+                "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+            )
 
     def test_webhooks_list_event_attempts(self) -> None:
         response = {

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -3,6 +3,7 @@ import hmac
 import time
 from hashlib import sha256
 from typing import Any, Dict
+from unittest import TestCase
 from unittest.mock import create_autospec
 
 import pytest
@@ -134,29 +135,6 @@ class TestWebhooks(ResendBaseTest):
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
-    def test_webhooks_replay_event(self) -> None:
-        self.patcher.stop()
-        client = create_autospec(HTTPClient, instance=True)
-        client.request.return_value = (
-            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
-            200,
-            {"Content-Type": "application/json"},
-        )
-        resend.default_http_client = client
-
-        event = resend.Webhooks.replay_event(
-            "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
-        )
-
-        assert event["object"] == "webhook_event"
-        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
-        _, kwargs = client.request.call_args
-        assert kwargs["method"] == "post"
-        assert (
-            kwargs["url"]
-            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
-        )
-
     def test_webhooks_list_event_attempts(self) -> None:
         response = {
             "object": "list",
@@ -192,6 +170,37 @@ class TestWebhooks(ResendBaseTest):
         result = resend.Webhooks.remove("wh_123")
         assert result["id"] == "wh_123"
         assert result["deleted"] is True
+
+
+class TestWebhooksRequest(TestCase):
+    def setUp(self) -> None:
+        resend.api_key = "re_123"
+        self.mock_client = create_autospec(HTTPClient, instance=True)
+        self.mock_client.name = "mock"
+        self.mock_client.request.return_value = (
+            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
+            200,
+            {"Content-Type": "application/json"},
+        )
+        self.previous_http_client = resend.default_http_client
+        resend.default_http_client = self.mock_client
+
+    def tearDown(self) -> None:
+        resend.default_http_client = self.previous_http_client
+
+    def test_replay_event_posts_to_the_replay_path(self) -> None:
+        event = resend.Webhooks.replay_event(
+            "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        )
+
+        assert event["object"] == "webhook_event"
+        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        _, kwargs = self.mock_client.request.call_args
+        assert kwargs["method"] == "post"
+        assert (
+            kwargs["url"]
+            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
+        )
 
 
 class TestWebhookVerification:

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -3,12 +3,10 @@ import hmac
 import time
 from hashlib import sha256
 from typing import Any, Dict
-from unittest.mock import create_autospec
 
 import pytest
 
 import resend
-from resend.http_client import HTTPClient
 from tests.conftest import ResendBaseTest
 
 
@@ -135,26 +133,19 @@ class TestWebhooks(ResendBaseTest):
         )
 
     def test_webhooks_replay_event(self) -> None:
-        self.patcher.stop()
-        client = create_autospec(HTTPClient, instance=True)
-        client.request.return_value = (
-            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
-            200,
-            {"Content-Type": "application/json"},
-        )
-        resend.default_http_client = client
+        response = {
+            "object": "webhook_event",
+            "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+        }
+        self.set_mock_json(response)
 
         event = resend.Webhooks.replay_event(
             "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
-        assert event["object"] == "webhook_event"
-        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
-        _, kwargs = client.request.call_args
-        assert kwargs["method"] == "post"
-        assert (
-            kwargs["url"]
-            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
+        assert event == response
+        self.mock.assert_called_once_with(
+            url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
         )
 
     def test_webhooks_list_event_attempts(self) -> None:

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -3,10 +3,12 @@ import hmac
 import time
 from hashlib import sha256
 from typing import Any, Dict
+from unittest.mock import create_autospec
 
 import pytest
 
 import resend
+from resend.http_client import HTTPClient
 from tests.conftest import ResendBaseTest
 
 
@@ -130,6 +132,29 @@ class TestWebhooks(ResendBaseTest):
         assert event == response
         self.mock.assert_called_once_with(
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        )
+
+    def test_webhooks_replay_event(self) -> None:
+        self.patcher.stop()
+        client = create_autospec(HTTPClient, instance=True)
+        client.request.return_value = (
+            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
+            200,
+            {"Content-Type": "application/json"},
+        )
+        resend.default_http_client = client
+
+        event = resend.Webhooks.replay_event(
+            "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        )
+
+        assert event["object"] == "webhook_event"
+        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        _, kwargs = client.request.call_args
+        assert kwargs["method"] == "post"
+        assert (
+            kwargs["url"]
+            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
         )
 
     def test_webhooks_list_event_attempts(self) -> None:

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -136,7 +136,7 @@ class TestWebhooks(ResendBaseTest):
             url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
-    def test_should_replay_event_raise_exception_when_no_content(self) -> None:
+    def test_replay_event_raises_exception_when_no_content(self) -> None:
         self.set_mock_json(None)
         with pytest.raises(NoContentError):
             _ = resend.Webhooks.replay_event(

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -3,10 +3,12 @@ import hmac
 import time
 from hashlib import sha256
 from typing import Any, Dict
+from unittest.mock import create_autospec
 
 import pytest
 
 import resend
+from resend.http_client import HTTPClient
 from tests.conftest import ResendBaseTest
 
 
@@ -133,19 +135,26 @@ class TestWebhooks(ResendBaseTest):
         )
 
     def test_webhooks_replay_event(self) -> None:
-        response = {
-            "object": "webhook_event",
-            "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
-        }
-        self.set_mock_json(response)
+        self.patcher.stop()
+        client = create_autospec(HTTPClient, instance=True)
+        client.request.return_value = (
+            b'{"object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}',
+            200,
+            {"Content-Type": "application/json"},
+        )
+        resend.default_http_client = client
 
         event = resend.Webhooks.replay_event(
             "wh_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
         )
 
-        assert event == response
-        self.mock.assert_called_once_with(
-            url="https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
+        assert event["object"] == "webhook_event"
+        assert event["id"] == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+        _, kwargs = client.request.call_args
+        assert kwargs["method"] == "post"
+        assert (
+            kwargs["url"]
+            == "https://api.resend.com/webhooks/wh_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay"
         )
 
     def test_webhooks_list_event_attempts(self) -> None:


### PR DESCRIPTION
Adds `POST /webhooks/{webhook_id}/events/{event_id}/replay` (`webhooks/replay-event`), which queues one more delivery of a webhook event to its webhook. Placed next to `get_event` / `get_event_async`, same argument style.

```python
def replay_event(cls, webhook_id: str, event_id: str) -> ReplayEventResponse
async def replay_event_async(cls, webhook_id: str, event_id: str) -> ReplayEventResponse
```

`ReplayEventResponse` is `{ object: "webhook_event", id: str }`.

```python
import resend

resend.api_key = "re_xxxxxxxxx"

replayed = resend.Webhooks.replay_event(
    "4dd369bc-aa82-4ff3-97de-514ae3000ee0", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
)
print(replayed["id"])
```

Also adds a replay call to `examples/webhooks.py`.

Spec PR: https://github.com/resend/resend-openapi/pull/112
API PR: https://github.com/resend/resend-monorepo/pull/9535
Docs page: https://resend.com/docs/api-reference/webhooks/replay-event

## Tests

The `ResendBaseTest` fixture mocks `Request.make_request(url)`, which hides the verb, and the verb is the only thing separating `replay_event` from `get_event`. The tests therefore swap `resend.default_http_client` / `resend.default_async_http_client` for a mock client and assert `method == "post"` plus the exact URL, the same shape as `TestSuppressionsRequestBody`. The setUp/tearDown is copied rather than lifted into `conftest.py` on purpose: this is the second copy per mode, not the third.

## Checks

- `tox -e lint` (flake8): passed
- `tox -e mypy`: passed, no issues in 181 files
- `tox -e py` (pytest): 626 passed

## Not verified live

No call was made against the API (write endpoint, no key configured for this task). The tests pin the verb and path; the only remaining assumption is the response body shape, which is pinned by the spec (`ReplayWebhookEventResponse`).

No version bump; that happens in a separate chore PR.

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2012