### PR TITLE
fix: preserve SDK errors for invalid JSON byte encodings

### DIFF
--- a/resend/async_request.py
+++ b/resend/async_request.py
@@ -170,7 +170,7 @@ class AsyncRequest(Generic[T]):
                 parsed_data["http_headers"] = dict(self._response_headers)
             # For list responses, return as-is (lists can't have headers key)
             return parsed_data
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             raise_for_code_and_type(
                 code=error_code,
                 message="Failed to decode JSON response",

--- a/resend/request.py
+++ b/resend/request.py
@@ -155,7 +155,7 @@ class Request(Generic[T]):
                 parsed_data["http_headers"] = dict(self._response_headers)
             # For list responses, return as-is (lists can't have headers key)
             return parsed_data
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             raise_for_code_and_type(
                 code=error_code,
                 message="Failed to decode JSON response",

--- a/resend/version.py
+++ b/resend/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.43.0"
+__version__ = "2.43.1"
 
 
 def get_version() -> str:

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -10,6 +10,46 @@ from resend.exceptions import (ApplicationError, RateLimitError, ResendError,
 from resend.version import get_version
 
 
+@pytest.mark.parametrize("content", [b'"\xff"', b'\xff\xfe{', b'not-json'])
+@pytest.mark.parametrize("status_code", [200, 429, 502])
+class TestResponseDecodingErrors:
+    def test_sync_preserves_status_and_headers(
+        self, content: bytes, status_code: int
+    ) -> None:
+        headers = {"content-type": "application/json", "retry-after": "2"}
+        response = Mock(content=content, status_code=status_code, headers=headers)
+        req = request.Request[Dict[str, Any]]("/emails", {}, "get")
+
+        with patch("resend.http_client_requests.requests.request", return_value=response):
+            with pytest.raises(ResendError) as error:
+                req.perform()
+
+        assert error.value.code == (status_code if status_code >= 400 else 500)
+        assert error.value.headers == headers
+        assert error.value.message == "Failed to decode JSON response"
+
+    @pytest.mark.asyncio
+    async def test_async_preserves_status_and_headers(
+        self, content: bytes, status_code: int
+    ) -> None:
+        from resend.async_request import AsyncRequest
+        from resend.http_client_httpx import HTTPXClient
+
+        headers = {"content-type": "application/json", "retry-after": "2"}
+        response = Mock(content=content, status_code=status_code, headers=headers)
+        req = AsyncRequest[Dict[str, Any]]("/emails", {}, "get")
+
+        with patch("resend.default_async_http_client", HTTPXClient()):
+            with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as send:
+                send.return_value = response
+                with pytest.raises(ResendError) as error:
+                    await req.perform()
+
+        assert error.value.code == (status_code if status_code >= 400 else 500)
+        assert error.value.headers == headers
+        assert error.value.message == "Failed to decode JSON response"
+
+
 class TestResendRequest(unittest.TestCase):
     @patch("resend.http_client_requests.requests.request")
     @patch("resend.api_key", new="test_key")

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -28,8 +29,7 @@ class TestResponseDecodingErrors:
         assert error.value.headers == headers
         assert error.value.message == "Failed to decode JSON response"
 
-    @pytest.mark.asyncio
-    async def test_async_preserves_status_and_headers(
+    def test_async_preserves_status_and_headers(
         self, content: bytes, status_code: int
     ) -> None:
         from resend.async_request import AsyncRequest
@@ -43,7 +43,7 @@ class TestResponseDecodingErrors:
             with patch("httpx.AsyncClient.request", new_callable=AsyncMock) as send:
                 send.return_value = response
                 with pytest.raises(ResendError) as error:
-                    await req.perform()
+                    asyncio.run(req.perform())
 
         assert error.value.code == (status_code if status_code >= 400 else 500)
         assert error.value.headers == headers


### PR DESCRIPTION
Malformed JSON bytes now raise the usual SDK error with the response status and headers in both sync and async requests. For example, a 429 response containing invalid UTF-8 previously leaked `UnicodeDecodeError`, bypassing the SDK error contract and its `Retry-After` metadata.

Validation: the new encoding cases produced 12 failures before the fix; all 646 tests now pass with `python -m pytest --cov=resend --cov-report=xml --doctest-modules tests`. The tests cover invalid UTF-8, truncated UTF-16 and malformed JSON at HTTP 200, 429 and 502 through both transport adapters. Source flake8 passes on Python 3.11, and mypy passes across `resend/`, `examples/` and `tests/` on Python 3.12.

No service deployment or new monitoring is needed for this SDK error conversion.

Agent-assisted: Codex prepared the patch and ran the local checks listed above.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync and async requests now convert invalid JSON byte encodings into the SDK’s standard error, preserving response status and headers. Previously, these responses leaked `UnicodeDecodeError` and could hide retry metadata such as `Retry-After`.

- Adds coverage for invalid UTF-8, truncated UTF-16, and malformed JSON across HTTP 200, 429, and 502 responses.

<sup>Written for commit aaa8a037af67ecd800e13699fd378447129bcf2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-python/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

